### PR TITLE
feat: add GitHub CLI (gh) support in home-manager

### DIFF
--- a/modules/home/cli/tools/gh/default.nix
+++ b/modules/home/cli/tools/gh/default.nix
@@ -8,10 +8,13 @@ with lib;
 with lib.${namespace};
 let
   cfg = config.${namespace}.cli.tools.gh;
+  sopsEnabled = config.${namespace}.security.sops.enable;
+  secretEnabled = sopsEnabled && cfg.githubToken;
 in
 {
   options.${namespace}.cli.tools.gh = with types; {
     enable = mkBoolOpt false "Whether or not to enable GitHub CLI";
+    githubToken = mkBoolOpt false "Whether to set GH_TOKEN from sops secret";
   };
 
   config = mkIf cfg.enable {
@@ -20,6 +23,14 @@ in
       settings = {
         git_protocol = "ssh";
       };
+    };
+
+    sops.secrets."gh-token" = mkIf secretEnabled {
+      sopsFile = ../../../secrets.yaml;
+    };
+
+    home.sessionVariables = mkIf secretEnabled {
+      GH_TOKEN = "$(cat ${config.sops.secrets."gh-token".path})";
     };
   };
 }

--- a/modules/home/cli/tools/gh/default.nix
+++ b/modules/home/cli/tools/gh/default.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  namespace,
+  ...
+}:
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.cli.tools.gh;
+in
+{
+  options.${namespace}.cli.tools.gh = with types; {
+    enable = mkBoolOpt false "Whether or not to enable GitHub CLI";
+  };
+
+  config = mkIf cfg.enable {
+    programs.gh = {
+      enable = true;
+      settings = {
+        git_protocol = "ssh";
+      };
+    };
+  };
+}

--- a/modules/home/roles/development/default.nix
+++ b/modules/home/roles/development/default.nix
@@ -133,6 +133,7 @@ in
           direnv.enable = true;
           eza.enable = true;
           fzf.enable = true;
+          gh.enable = true;
           git.enable = true;
           htop.enable = true;
           modern-unix.enable = true;

--- a/modules/home/roles/development/default.nix
+++ b/modules/home/roles/development/default.nix
@@ -133,7 +133,10 @@ in
           direnv.enable = true;
           eza.enable = true;
           fzf.enable = true;
-          gh.enable = true;
+          gh = {
+            enable = true;
+            githubToken = true;
+          };
           git.enable = true;
           htop.enable = true;
           modern-unix.enable = true;

--- a/modules/home/secrets.yaml
+++ b/modules/home/secrets.yaml
@@ -1,4 +1,5 @@
 system-network-wifi-password: ENC[AES256_GCM,data:sGZZ6fly1b8=,iv:FaGMkyJ+EWsTmquKLDA/kInYNrrK3b3Kld12ZCVCN4M=,tag:RR8Lg9xEfkgFLwqDwHWAWw==,type:str]
+gh-token: ENC[AES256_GCM,data:18BO0NJlbn/100ria7zoUXGb88ftQ6hw77dmYgScX5OI2LMCcLjIXQ==,iv:MumbaKS4gcqLoqvW7QiTijRx/euBh2IlizOurkCNPUc=,tag:buRFYHzHC+aWbypqrRXKBg==,type:str]
 sops:
     age:
         - recipient: age1kjlpt0mu072vqk8txgkfs7yvehkvk0kysawyqvy96zcqmf49wgkq3hlsag
@@ -19,8 +20,8 @@ sops:
             ejlzSUZmU1EwQUxEOThQc3htS2NxdnMK/rtPglJ1uL/mKKbkQlyuVvn4mwwlp3K2
             ge1EZgmK6PN7fl4mBfNSjQcGu5F4TLSEoW0+srv4vlhGu+GrBPh/KA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-17T15:05:40Z"
-    mac: ENC[AES256_GCM,data:MPPmUlNt/d4G+l08eGWxlb6r+Z/64rE9o9BwKYra0Hbhm4XLsSJB4YL6gh8NOzN3CMGT2fXYTiYE7ogADwQPya6w3vN3o7asMuMz+suvS6ygTmaQN6AGd9WWT5cZrrPw1nrdwnCB8YwP01d6+KgL5xlmurP0U3YfGNkrJW89GCY=,iv:SET8o85HXw5iDtfEdW2buveVrScNXVwRbhJr/ywBUok=,tag:jNewgkwxmjyL6uqg/XYdhw==,type:str]
+    lastmodified: "2026-03-19T13:13:40Z"
+    mac: ENC[AES256_GCM,data:PG3NBg8zQ0drQVPUZN7kRxxsvmyFjm0MkFy7xrkjf7rlO1+wr4APeBeQyzpwGBrXSBvhRpA6Zb+8cyCh/x1l/OWdf8DKqo1LU7hJ6zdSDlIv0fmoXT3jBWKR9NfFmxkMRBuVcIATKYutrNgcS1vZl3gZyfh89D8p/rsp94i9hjw=,iv:SsqmcWcNEPVJqkHyHNU052cbCYJaR2aQh819GFCqVcM=,tag:cIz9PmjUa0vBxpD3FUEj6g==,type:str]
     pgp:
         - created_at: "2026-02-17T14:52:58Z"
           enc: |-
@@ -34,4 +35,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 07E36E87C0270E464DB4D663B423D1630A58837C
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/modules/home/security/sops/default.nix
+++ b/modules/home/security/sops/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   inputs,
   namespace,
   ...
@@ -10,6 +11,8 @@ with lib.${namespace};
 let
   cfg = config.${namespace}.security.sops;
   home = config.home.homeDirectory;
+  secretsBase =
+    if pkgs.stdenv.isDarwin then "${home}/.local/share/sops-nix" else "%r";
 in
 {
   options.${namespace}.security.sops = with types; {
@@ -27,8 +30,8 @@ in
         sshKeyPaths = [ ];
       };
 
-      defaultSymlinkPath = "%r/secrets";
-      defaultSecretsMountPoint = "%r/secrets.d";
+      defaultSymlinkPath = "${secretsBase}/secrets";
+      defaultSecretsMountPoint = "${secretsBase}/secrets.d";
     };
   };
 }

--- a/modules/home/security/sops/default.nix
+++ b/modules/home/security/sops/default.nix
@@ -11,8 +11,7 @@ with lib.${namespace};
 let
   cfg = config.${namespace}.security.sops;
   home = config.home.homeDirectory;
-  secretsBase =
-    if pkgs.stdenv.isDarwin then "${home}/.local/share/sops-nix" else "%r";
+  secretsBase = if pkgs.stdenv.isDarwin then "${home}/.local/share/sops-nix" else "%r";
 in
 {
   options.${namespace}.security.sops = with types; {


### PR DESCRIPTION
## Summary
- Add new `gh` home-manager module (`modules/home/cli/tools/gh/`) with SSH protocol default and optional `GH_TOKEN` via sops secret
- Enable `gh` with token support in the development role
- Fix sops secrets path for macOS (darwin) compatibility using `~/.local/share/sops-nix` instead of `%r`

## Test plan
- [x] Lint and format pass
- [x] Verify `gh auth status` works on deployed system
- [x] Verify `GH_TOKEN` is set from sops secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)