### PR TITLE
feat(claude-code): migrate to llm-agents.nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,31 @@
         "type": "github"
       }
     },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771437256,
+        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -82,6 +107,40 @@
         "owner": "Homebrew",
         "ref": "5.0.12",
         "repo": "brew",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
         "type": "github"
       }
     },
@@ -350,6 +409,27 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
           "neovim-nightly-overlay",
           "nixpkgs"
         ]
@@ -368,7 +448,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "nixos-anywhere",
@@ -389,7 +469,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nixvim",
@@ -410,7 +490,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "nur",
@@ -431,7 +511,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
@@ -452,7 +532,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": [
           "terranix",
@@ -512,7 +592,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -530,7 +610,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -548,7 +628,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_9"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -566,7 +646,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_12"
+        "systems": "systems_13"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -864,6 +944,21 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "ixx": {
       "inputs": {
         "flake-utils": [
@@ -892,6 +987,31 @@
         "type": "github"
       }
     },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_5",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1774104280,
+        "narHash": "sha256-kQeR1qqTFleJzMWsOttJMWUxMsykcKrUA2ttPIg2O4k=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "4f6fca6b05c5b59b6bbb442a262596ddf86661e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
         "fenix": "fenix",
@@ -917,7 +1037,7 @@
     },
     "neovim-nightly-overlay": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "neovim-src": "neovim-src",
         "nixpkgs": "nixpkgs_2"
       },
@@ -1075,14 +1195,14 @@
         "disko": [
           "disko"
         ],
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nix-vm-test": "nix-vm-test",
         "nixos-images": "nixos-images",
         "nixos-stable": "nixos-stable",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1769956140,
@@ -1272,12 +1392,12 @@
     },
     "nixvim": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1769049374,
@@ -1296,7 +1416,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1418,7 +1538,7 @@
           "nixpkgs"
         ],
         "pyproject-nix": "pyproject-nix",
-        "systems": "systems_8"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1772052460,
@@ -1472,6 +1592,7 @@
         "hyprcursor": "hyprcursor",
         "hyprpanel": "hyprpanel",
         "impermanence": "impermanence",
+        "llm-agents": "llm-agents",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
@@ -1583,13 +1704,13 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "gnome-shell": "gnome-shell",
         "nixpkgs": [
           "nixpkgs"
         ],
         "nur": "nur_2",
-        "systems": "systems_10",
+        "systems": "systems_11",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -1657,6 +1778,21 @@
       }
     },
     "systems_12": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_13": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1763,21 +1899,6 @@
     },
     "systems_8": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "systems_9": {
-      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -1791,13 +1912,28 @@
         "type": "github"
       }
     },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
     "terranix": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_11"
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1772179377,
@@ -1895,6 +2031,27 @@
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixos-anywhere",

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # AI tools
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Darwin (macOS)
     darwin = {
       url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
@@ -246,6 +252,7 @@
       overlays = with inputs; [
         nixgl.overlay
         nur.overlays.default
+        llm-agents.overlays.default
         # Make unstable packages available as pkgs.unstable
         (final: _prev: {
           unstable = import nixpkgs-unstable {

--- a/homes/aarch64-darwin/oleksandrsy@workbook/default.nix
+++ b/homes/aarch64-darwin/oleksandrsy@workbook/default.nix
@@ -10,9 +10,6 @@ with lib.${namespace};
   nix-config = {
     roles.work = enabled;
 
-    # Use Homebrew claude-code for latest version
-    development.ai.claude-code.install = mkForce false;
-
     user = {
       enable = true;
       name = mkForce "oleksandrsy";

--- a/infra/router/default.nix
+++ b/infra/router/default.nix
@@ -26,14 +26,14 @@ let
       {
         routeros = {
           connection = {
-            gateway = defaults.network.gateway;
+            inherit (defaults.network) gateway;
             username = defaults.user;
           };
 
           system.timezone = defaults.locale.timeZone;
 
           network = {
-            subnet = defaults.network.subnet;
+            inherit (defaults.network) subnet;
             dhcp.server.range = defaults.network.dhcpRange;
           };
 
@@ -54,13 +54,13 @@ let
           };
 
           dns = {
-            upstream = defaults.network.dns.upstream;
+            inherit (defaults.network.dns) upstream;
             localDomain = defaults.network.domains.local;
           };
 
           wifi = {
             enable = true;
-            ssid = defaults.network.wifi.ssid;
+            inherit (defaults.network.wifi) ssid;
             country = "ukraine";
           };
 

--- a/justfile
+++ b/justfile
@@ -107,6 +107,11 @@ update:
     @echo "📦 Updating flake inputs..."
     nix flake update
 
+# Update a single flake input
+update-input input:
+    @echo "📦 Updating {{input}}..."
+    nix flake update {{input}}
+
 # Check flake for issues
 check:
     @echo "🔍 Checking flake configuration..."

--- a/justfile
+++ b/justfile
@@ -102,15 +102,10 @@ build-test:
     @echo "🧪 Testing build configuration..."
     nixos-rebuild build --flake .
 
-# Update flake inputs
-update:
+# Update flake inputs (optionally a single input)
+update *input:
     @echo "📦 Updating flake inputs..."
-    nix flake update
-
-# Update a single flake input
-update-input input:
-    @echo "📦 Updating {{input}}..."
-    nix flake update {{input}}
+    nix flake update {{ input }}
 
 # Check flake for issues
 check:

--- a/modules/darwin/system/nix/default.nix
+++ b/modules/darwin/system/nix/default.nix
@@ -36,10 +36,12 @@ in
         substituters = [
           "https://cache.nixos.org/"
           "https://nix-community.cachix.org"
+          "https://cache.numtide.com"
         ];
         trusted-public-keys = [
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+          "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         ];
       };
 

--- a/modules/home/development/ai/claude-code/default.nix
+++ b/modules/home/development/ai/claude-code/default.nix
@@ -38,6 +38,20 @@ in
         - `docs/specs/` - Feature specifications and requirements
         - `docs/plans/` - Implementation plans
       '';
+
+      file.".claude/settings.json".text = lib.generators.toJSON { } {
+        attribution = {
+          commit = "";
+          pr = "";
+        };
+        model = "claude-opus-4-6";
+        enabledPlugins = {
+          "superpowers@superpowers-marketplace" = true;
+          "superpowers@claude-plugins-official" = true;
+        };
+        alwaysThinkingEnabled = true;
+        skipDangerousModePermissionPrompt = true;
+      };
     };
   };
 }

--- a/modules/home/development/ai/claude-code/default.nix
+++ b/modules/home/development/ai/claude-code/default.nix
@@ -13,17 +13,13 @@ in
 {
   options.${namespace}.development.ai.claude-code = with types; {
     enable = mkEnableOption "Whether or not to enable claude-code";
-    install = mkBoolOpt true "Whether to install claude-code package via home-manager";
   };
 
   config = mkIf cfg.enable {
     home = {
-      packages = mkIf cfg.install (
-        with pkgs;
-        [
-          claude-code
-        ]
-      );
+      packages = [
+        pkgs.llm-agents.claude-code
+      ];
 
       shellAliases = {
         cl = "claude";

--- a/modules/nixos/system/nix/default.nix
+++ b/modules/nixos/system/nix/default.nix
@@ -46,10 +46,12 @@ in
         substituters = [
           "https://cache.nixos.org/"
           "https://nix-community.cachix.org"
+          "https://cache.numtide.com"
         ];
         trusted-public-keys = [
           "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
           "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+          "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         ];
 
       };

--- a/systems/aarch64-darwin/workbook/default.nix
+++ b/systems/aarch64-darwin/workbook/default.nix
@@ -15,9 +15,6 @@ with lib.${namespace};
     # Override user name for this machine
     user.name = mkForce "oleksandrsy";
 
-    # claude-code via Homebrew for latest version
-    system.homebrew.casks = [ "claude-code" ];
-
     system.networking = {
       knownNetworkServices = [
         "Wi-Fi"


### PR DESCRIPTION
## Summary

Integrate [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix) flake for managing AI tools, starting with claude-code.

## Changes

- **Add llm-agents.nix flake input** with nixpkgs follows and overlay
- **Migrate claude-code package** from nixpkgs/homebrew to `pkgs.llm-agents.claude-code`
- **Remove install toggle** — always install via home-manager on all platforms
- **Remove homebrew cask** for claude-code on macOS
- **Add numtide binary cache** to both NixOS and Darwin nix modules
- **Manage settings.json declaratively** via `lib.generators.toJSON` instead of static JSON file
- **Add `just update-input` recipe** for updating individual flake inputs