### PR TITLE
feat(media-tool): add media-tools CLI (media-normalize, media-import)

### DIFF
--- a/docs/plans/2026-04-09-media-tools.md
+++ b/docs/plans/2026-04-09-media-tools.md
@@ -1,0 +1,595 @@
+# Media Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two CLI tools (`media-normalize`, `media-import`) packaged as a Nix derivation with a home-manager module for managing personal media files.
+
+**Architecture:** Shell scripts wrapped via `pkgs.writeShellScriptBin` inside a Nix package at `packages/media-tools/`. A thin home-manager module at `modules/home/media/tools/` enables the package and sets `MEDIA_HOME`. The media role aggregates this module.
+
+**Tech Stack:** Bash, exiftool, Nix (snowfall-lib), home-manager
+
+**Spec:** `docs/specs/2026-04-09-media-tools-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/media-tools/default.nix` | Nix derivation: builds `media-normalize` and `media-import` scripts with wrapped deps |
+| `packages/media-tools/media-normalize.sh` | Shell script: normalize media filenames and EXIF metadata |
+| `packages/media-tools/media-import.sh` | Shell script: import media into `$MEDIA_HOME/All/YYYY/MM/` |
+| `packages/media-tools/media-common.sh` | Shared constants and helpers (extensions, filename patterns, argument parsing) |
+| `modules/home/media/tools/default.nix` | Home-manager module: enable toggle + `MEDIA_HOME` config |
+| `modules/home/roles/media/default.nix` | Modify: add `tools = enabled;` to media role |
+
+---
+
+### Task 1: Shared helpers (`media-common.sh`)
+
+**Files:**
+- Create: `packages/media-tools/media-common.sh`
+
+- [ ] **Step 1: Create shared constants and helper functions**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTENSIONS="jpg jpeg png heic mp4 mov"
+FILENAME_FORMAT="%Y%m%d_%H%M%S%%-c.%%e"
+MIN_FILE_SIZE=30000  # 30KB - skip thumbnails/artifacts
+
+# Normalized filename pattern: YYYYMMDD_HHMMSS with optional -N suffix
+NORMALIZED_PATTERN='^[0-9]{8}_[0-9]{6}(-[0-9]+)?\.'
+
+# Filename date patterns for fallback parsing
+# Returns date string in "YYYY:MM:DD HH:MM:SS" exiftool format, or empty
+parse_date_from_filename() {
+  local filename
+  filename=$(basename "$1")
+  filename="${filename%.*}"  # strip extension
+
+  local date_str=""
+
+  # Try each pattern
+  if [[ "$filename" =~ ^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2}) ]]; then
+    date_str="${BASH_REMATCH[2]}:${BASH_REMATCH[3]}:${BASH_REMATCH[4]} ${BASH_REMATCH[5]}:${BASH_REMATCH[6]}:${BASH_REMATCH[7]}"
+  elif [[ "$filename" =~ ([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2}) ]]; then
+    date_str="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}:${BASH_REMATCH[3]} ${BASH_REMATCH[4]}:${BASH_REMATCH[5]}:${BASH_REMATCH[6]}"
+  fi
+
+  echo "$date_str"
+}
+
+# Build exiftool extension args: -ext jpg -ext jpeg -ext png ...
+exiftool_ext_args() {
+  local args=""
+  for ext in $EXTENSIONS; do
+    args="$args -ext $ext"
+  done
+  echo "$args"
+}
+
+# Print error to stderr
+print_error() {
+  echo "ERROR: $1" >&2
+}
+
+# Print info message
+print_info() {
+  echo ":: $1"
+}
+
+# Parse common flags. Sets DRY_RUN, RECURSIVE, and remaining args in POSITIONAL.
+# Tool-specific flags (e.g. --move) should be parsed before calling this.
+DRY_RUN=false
+RECURSIVE=false
+POSITIONAL=()
+
+parse_common_args() {
+  DRY_RUN=false
+  RECURSIVE=false
+  POSITIONAL=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)  DRY_RUN=true; shift ;;
+      --recursive) RECURSIVE=true; shift ;;
+      --help|-h)  usage; exit 0 ;;
+      -*)         print_error "Unknown option: $1"; usage; exit 1 ;;
+      *)          POSITIONAL+=("$1"); shift ;;
+    esac
+  done
+}
+
+# Exiftool maxdepth flag based on RECURSIVE
+exiftool_depth_args() {
+  if [[ "$RECURSIVE" == false ]]; then
+    echo "-maxdepth 0"
+  fi
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/media-tools/media-common.sh
+git commit -m "feat(media-tools): add shared helpers and constants"
+```
+
+---
+
+### Task 2: `media-normalize` script
+
+**Files:**
+- Create: `packages/media-tools/media-normalize.sh`
+
+- [ ] **Step 1: Create the media-normalize script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+usage() {
+  cat <<EOF
+Usage: media-normalize [OPTIONS] [DIRECTORY]
+
+Normalize media filenames and EXIF metadata in-place.
+
+Steps:
+  1. Lowercase file extensions
+  2. Fill missing EXIF CreateDate (from filename or mtime)
+  3. Rename files to YYYYMMDD_HHMMSS format
+
+Options:
+  --dry-run     Preview changes without modifying files
+  --recursive   Process subdirectories
+  -h, --help    Show this help
+
+DIRECTORY defaults to current directory.
+EOF
+}
+
+# Step 1: Lowercase extensions
+lowercase_extensions() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    local EXT
+    EXT=$(echo "$ext" | tr '[:lower:]' '[:upper:]')
+    # Find files with uppercase extension
+    while IFS= read -r -d '' file; do
+      local newfile="${file%."$EXT"}.$ext"
+      if [[ "$DRY_RUN" == true ]]; then
+        print_info "[dry-run] Rename: $file -> $newfile"
+      else
+        mv -- "$file" "$newfile"
+        print_info "Renamed: $file -> $newfile"
+      fi
+    done < <(find "$dir" "${find_depth[@]}" -name "*.$EXT" -type f -print0 2>/dev/null)
+  done
+}
+
+# Step 2: Fill missing EXIF CreateDate
+fill_missing_dates() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    while IFS= read -r -d '' file; do
+      # Check if CreateDate exists and is valid
+      local create_date
+      create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+
+      if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
+        continue  # already has valid date
+      fi
+
+      # Fallback 1: parse from filename
+      local parsed_date
+      parsed_date=$(parse_date_from_filename "$file")
+
+      if [[ -n "$parsed_date" ]]; then
+        if [[ "$DRY_RUN" == true ]]; then
+          print_info "[dry-run] Set CreateDate from filename: $file -> $parsed_date"
+        else
+          exiftool -overwrite_original -CreateDate="$parsed_date" "$file"
+          print_info "Set CreateDate from filename: $file -> $parsed_date"
+        fi
+        continue
+      fi
+
+      # Fallback 2: file modification date
+      if [[ "$DRY_RUN" == true ]]; then
+        print_info "[dry-run] Set CreateDate from mtime: $file"
+      else
+        exiftool -overwrite_original '-CreateDate<FileModifyDate' "$file"
+        print_info "Set CreateDate from mtime: $file"
+      fi
+    done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
+  done
+}
+
+# Step 3: Rename files to canonical format
+rename_files() {
+  local dir="$1"
+  local depth_args
+  depth_args=$(exiftool_depth_args)
+
+  # Skip files already matching the normalized pattern
+  # exiftool -if condition skips files whose basename matches YYYYMMDD_HHMMSS
+  local dry_run_flag=""
+  if [[ "$DRY_RUN" == true ]]; then
+    dry_run_flag="-testname"
+  else
+    dry_run_flag="-filename"
+  fi
+
+  # shellcheck disable=SC2086
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if 'not ($filename =~ /^[0-9]{8}_[0-9]{6}/)' \
+    "${dry_run_flag}<CreateDate" \
+    -d "$FILENAME_FORMAT" \
+    -overwrite_original \
+    "$dir" 2>/dev/null || true
+}
+
+# Main
+parse_common_args "$@"
+DIR="${POSITIONAL[0]:-.}"
+
+if [[ ! -d "$DIR" ]]; then
+  print_error "Directory does not exist: $DIR"
+  exit 1
+fi
+
+print_info "Normalizing media in: $DIR"
+[[ "$DRY_RUN" == true ]] && print_info "DRY RUN - no files will be modified"
+
+lowercase_extensions "$DIR"
+fill_missing_dates "$DIR"
+rename_files "$DIR"
+
+print_info "Done."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/media-tools/media-normalize.sh
+git commit -m "feat(media-tools): add media-normalize script"
+```
+
+---
+
+### Task 3: `media-import` script
+
+**Files:**
+- Create: `packages/media-tools/media-import.sh`
+
+- [ ] **Step 1: Create the media-import script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+MOVE=false
+
+usage() {
+  cat <<EOF
+Usage: media-import [OPTIONS] [SOURCE]
+
+Import media files into \$MEDIA_HOME/All/YYYY/MM/ structure.
+
+Options:
+  --dry-run     Preview changes without modifying files
+  --move        Move files instead of copy (default: copy)
+  --recursive   Process subdirectories
+  -h, --help    Show this help
+
+SOURCE defaults to current directory.
+Requires MEDIA_HOME environment variable.
+EOF
+}
+
+# Override parse_common_args to handle --move
+parse_args() {
+  local remaining=()
+  MOVE=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --move) MOVE=true; shift ;;
+      *)      remaining+=("$1"); shift ;;
+    esac
+  done
+
+  parse_common_args "${remaining[@]}"
+}
+
+# Main
+parse_args "$@"
+SRC="${POSITIONAL[0]:-.}"
+
+if [[ -z "${MEDIA_HOME:-}" ]]; then
+  print_error "MEDIA_HOME environment variable is not set."
+  print_error "Set it to your media library root (e.g., ~/Pictures/Photo)"
+  exit 1
+fi
+
+if [[ ! -d "$SRC" ]]; then
+  print_error "Source directory does not exist: $SRC"
+  exit 1
+fi
+
+DST="$MEDIA_HOME/All"
+mkdir -p "$DST"
+
+print_info "Importing media from: $SRC"
+print_info "Destination: $DST"
+[[ "$DRY_RUN" == true ]] && print_info "DRY RUN - no files will be modified"
+[[ "$MOVE" == true ]] && print_info "Mode: move" || print_info "Mode: copy"
+
+depth_args=$(exiftool_depth_args)
+dst_format="$DST/%Y/%m/$FILENAME_FORMAT"
+
+# Common exiftool args for selecting media files above size threshold
+# shellcheck disable=SC2086
+run_exiftool_import() {
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if "\$filesize# > $MIN_FILE_SIZE" \
+    "$@" \
+    "$SRC" 2>/dev/null || true
+}
+
+if [[ "$DRY_RUN" == true ]]; then
+  # Preview: use -p to print source -> destination mapping without copying
+  # shellcheck disable=SC2086
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if "\$filesize# > $MIN_FILE_SIZE" \
+    -p "\$filename -> $DST/\$DateTimeOriginal" \
+    -d "%Y/%m/%Y%m%d_%H%M%S.%le" \
+    "$SRC" 2>/dev/null || true
+elif [[ "$MOVE" == true ]]; then
+  # Collect matching source file paths before copying
+  mapfile -d '' src_files < <(
+    # shellcheck disable=SC2086
+    exiftool $depth_args $(exiftool_ext_args) \
+      -if "\$filesize# > $MIN_FILE_SIZE" \
+      -print0 "$SRC" 2>/dev/null || true
+  )
+
+  if [[ ${#src_files[@]} -eq 0 ]]; then
+    print_info "No files to import."
+  else
+    # Copy to destination (no || true — fail loudly on copy errors)
+    # shellcheck disable=SC2086
+    exiftool \
+      $depth_args \
+      $(exiftool_ext_args) \
+      -if "\$filesize# > $MIN_FILE_SIZE" \
+      -o "$dst_format" \
+      -d "$dst_format" \
+      -progress \
+      "$SRC"
+
+    # Delete source files after successful copy
+    for file in "${src_files[@]}"; do
+      rm -- "$file"
+      print_info "Removed source: $file"
+    done
+  fi
+else
+  # Copy mode
+  run_exiftool_import -o "$dst_format" -d "$dst_format" -progress
+fi
+
+print_info "Done."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/media-tools/media-import.sh
+git commit -m "feat(media-tools): add media-import script"
+```
+
+---
+
+### Task 4: Nix package derivation
+
+**Files:**
+- Create: `packages/media-tools/default.nix`
+
+- [ ] **Step 1: Create the Nix package**
+
+```nix
+{
+  pkgs,
+  lib,
+  ...
+}:
+let
+  runtimeDeps = with pkgs; [
+    exiftool
+    coreutils
+    findutils
+  ];
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "media-tools";
+  version = "1.0.0";
+  src = ./.;
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/media-tools
+
+    # Install shared lib
+    cp media-common.sh $out/lib/media-tools/
+
+    # Install scripts and wrap with runtime deps
+    for script in media-normalize media-import; do
+      cp "$script.sh" "$out/bin/$script"
+      chmod +x "$out/bin/$script"
+
+      # Patch source path to point to installed location
+      substituteInPlace "$out/bin/$script" \
+        --replace-fail 'SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"' \
+        'SCRIPT_DIR="${placeholder "out"}/lib/media-tools"'
+
+      wrapProgram "$out/bin/$script" \
+        --prefix PATH : ${lib.makeBinPath runtimeDeps}
+    done
+  '';
+
+  meta = with lib; {
+    description = "CLI tools for managing personal media files";
+    platforms = platforms.all;
+  };
+}
+```
+
+- [ ] **Step 2: Verify the package builds**
+
+```bash
+cd /Users/oleksandrsy/.nix-config
+nix build .#media-tools
+# Verify binaries exist
+ls -la result/bin/
+result/bin/media-normalize --help
+result/bin/media-import --help
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/media-tools/default.nix
+git commit -m "feat(media-tools): add Nix package derivation"
+```
+
+---
+
+### Task 5: Home-manager module
+
+**Files:**
+- Create: `modules/home/media/tools/default.nix`
+- Modify: `modules/home/roles/media/default.nix`
+
+- [ ] **Step 1: Create the home-manager module**
+
+```nix
+{
+  config,
+  lib,
+  pkgs,
+  namespace,
+  ...
+}:
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.media.tools;
+in
+{
+  options.${namespace}.media.tools = {
+    enable = mkBoolOpt false "Media management CLI tools (media-normalize, media-import)";
+    mediaHome = mkOpt types.str "${config.home.homeDirectory}/Pictures/Photo" "Root directory for media library";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.${namespace}.media-tools ];
+    home.sessionVariables.MEDIA_HOME = cfg.mediaHome;
+  };
+}
+```
+
+- [ ] **Step 2: Add tools to media role**
+
+In `modules/home/roles/media/default.nix`, add `tools = enabled;` to the `${namespace}.media` block:
+
+```nix
+config = mkIf cfg.enable {
+  ${namespace}.media = {
+    players.vlc = enabled;
+    shotwell = enabled;
+    tools = enabled;
+  };
+};
+```
+
+- [ ] **Step 3: Verify flake check passes**
+
+```bash
+cd /Users/oleksandrsy/.nix-config
+nix flake check
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/home/media/tools/default.nix modules/home/roles/media/default.nix
+git commit -m "feat(media-tools): add home-manager module and role integration"
+```
+
+---
+
+### Task 6: Manual testing
+
+- [ ] **Step 1: Build the package and test with sample files**
+
+```bash
+nix build .#media-tools
+
+# Create test directory with sample files
+mkdir -p /tmp/media-test
+# Copy a few test images/videos there, or create dummy ones
+
+# Test normalize
+result/bin/media-normalize --dry-run /tmp/media-test
+
+# Test import
+MEDIA_HOME=/tmp/media-output result/bin/media-import --dry-run /tmp/media-test
+```
+
+- [ ] **Step 2: Test error cases**
+
+```bash
+# Missing MEDIA_HOME
+unset MEDIA_HOME
+result/bin/media-import /tmp/media-test  # should error
+
+# Non-existent directory
+result/bin/media-normalize /tmp/nonexistent  # should error
+
+# Help flags
+result/bin/media-normalize --help
+result/bin/media-import --help
+```
+
+- [ ] **Step 3: Fix any issues found during testing**
+
+- [ ] **Step 4: Final commit if fixes were needed**

--- a/docs/specs/2026-04-09-media-tools-design.md
+++ b/docs/specs/2026-04-09-media-tools-design.md
@@ -1,0 +1,126 @@
+# Media Tools CLI
+
+## Goal
+
+Provide two CLI tools (`media-normalize`, `media-import`) for managing personal media files — normalizing filenames/metadata and organizing into a canonical folder structure.
+
+## Background
+
+Ported from [old dotfiles](https://github.com/aleks-sidorenko/dotfiles/blob/master/shell/plugins/img/img.plugin.zsh) with improved naming, separation of concerns, and consistent argument handling. Phone mount/import is out of scope — will be a separate module.
+
+## Conventions
+
+- **All dates are local time.** No timezone conversion is performed. EXIF `CreateDate` is local time by convention; filename-parsed and mtime dates are also local.
+- **Idempotency.** Both tools are safe to run multiple times. Files already matching the target name pattern (`YYYYMMDD_HHMMSS[%-c].ext`) with a valid EXIF `CreateDate` are skipped by `media-normalize`. Files already present at the destination are handled by exiftool's `%-c` auto-increment in `media-import`.
+
+## Tools
+
+### `media-normalize`
+
+Fix metadata and filenames in-place within a directory.
+
+**Steps (in order):**
+1. Lowercase file extensions via shell `mv` (`.JPG` → `.jpg`, `.MOV` → `.mov`)
+2. Fill missing EXIF `CreateDate` using fallback chain (see below) — writes to the file-type-appropriate tag (exiftool handles this automatically when writing `-CreateDate`)
+3. Skip renaming for files whose filename already matches `YYYYMMDD_HHMMSS*.ext` and have a valid `CreateDate` (EXIF backfill in step 2 still applies)
+4. Rename remaining files to `YYYYMMDD_HHMMSS%-c.ext` based on resolved `CreateDate`
+
+**Date fallback chain:**
+1. Existing EXIF `CreateDate` — use as-is (skip if `0000:00:00 00:00:00`)
+2. Parse date from filename — supported patterns:
+   - `YYYYMMDD_HHMMSS` (target format)
+   - `IMG_YYYYMMDD_HHMMSS` (Android/iOS camera)
+   - `PXL_YYYYMMDD_HHMMSS` (Pixel camera)
+   - `VID_YYYYMMDD_HHMMSS` (Android video)
+   - `Screenshot_YYYYMMDD_HHMMSS` (screenshots)
+   - `YYYY-MM-DD_HH-MM-SS` (alternative separator)
+   - `YYYY-MM-DD HH.MM.SS` (macOS screenshots)
+3. File modification date — last resort
+
+When a date is resolved from fallback (steps 2-3), it is written back to EXIF `CreateDate` before renaming.
+
+**Usage:**
+```
+media-normalize [OPTIONS] [DIRECTORY]
+```
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Preview changes without modifying files |
+| `--recursive` | Process subdirectories |
+| (no flag) | Process only top-level files in directory |
+
+- `DIRECTORY` defaults to `.`
+
+**Notes:**
+- PNG files rarely have EXIF `CreateDate` — they will typically hit the filename-parse or mtime fallback.
+- Video files (`.mp4`, `.mov`) use QuickTime metadata tags internally; exiftool maps `-CreateDate` to the correct tag per format.
+
+### `media-import`
+
+Organize media files into the canonical folder structure. Does not modify source files in-place — only reads metadata to determine destination path.
+
+**What it does:**
+- Reads `CreateDate` from source files to determine `YYYY/MM` destination
+- Copies (or moves) files into `$MEDIA_HOME/All/YYYY/MM/YYYYMMDD_HHMMSS%-c.ext`
+- Skips files smaller than 30KB (filters thumbnails and messaging app artifacts)
+- Uses exiftool's `-o` which is aware of existing files at the destination — `%-c` increments correctly across runs
+- If source files have no `CreateDate` (e.g., PNG without EXIF), falls back to file modification date for destination path — run `media-normalize` first for best results
+
+**Usage:**
+```
+media-import [OPTIONS] [SOURCE]
+```
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Preview changes without modifying files |
+| `--move` | Move files instead of copy (default: copy) |
+| `--recursive` | Process subdirectories |
+| (no flag) | Process only top-level files in source |
+
+- `SOURCE` defaults to `.`
+- Requires `MEDIA_HOME` environment variable — errors with a clear message if unset
+
+### Supported Extensions
+
+`jpg`, `jpeg`, `png`, `heic`, `mp4`, `mov`
+
+### Filename Format
+
+`YYYYMMDD_HHMMSS%-c.ext` where `%-c` is exiftool's auto-increment copy number for same-second duplicates. The first file has no suffix; duplicates get `-1`, `-2`, etc. Extensions are always lowercase.
+
+## Error Handling
+
+- Unsupported file extensions: silently skipped
+- Missing `MEDIA_HOME` (on `media-import`): error with message
+- Non-existent source directory: error
+- `--dry-run`: prints what would happen, no modifications
+
+## Nix Architecture
+
+### Package: `packages/media-tools/`
+
+Nix derivation producing `media-normalize` and `media-import` scripts with wrapped runtime dependencies:
+- `exiftool`
+- `coreutils`
+
+### Home-manager module: `modules/home/media/tools/`
+
+```nix
+options.${namespace}.media.tools = {
+  enable = mkBoolOpt false "Media management CLI tools";
+  mediaHome = mkOpt types.str
+    "${config.home.homeDirectory}/Pictures/Photo"
+    "Root directory for media library";
+};
+
+config = mkIf cfg.enable {
+  home.packages = [ pkgs.nix-config.media-tools ];
+  home.sessionVariables.MEDIA_HOME = cfg.mediaHome;
+};
+```
+
+### Role integration
+
+`modules/home/roles/media/` updated to include `nix-config.media.tools = enabled;`.

--- a/docs/specs/2026-04-09-media-tools-design.md
+++ b/docs/specs/2026-04-09-media-tools-design.md
@@ -21,8 +21,10 @@ Fix metadata and filenames in-place within a directory.
 
 **Steps (in order):**
 1. Lowercase file extensions via shell `mv` (`.JPG` → `.jpg`, `.MOV` → `.mov`)
-2. Fill missing EXIF `CreateDate` using fallback chain (see below) — writes to the file-type-appropriate tag (exiftool handles this automatically when writing `-CreateDate`)
-3. Skip renaming for files whose filename already matches `YYYYMMDD_HHMMSS*.ext` and have a valid `CreateDate` (EXIF backfill in step 2 still applies)
+2. Set EXIF `CreateDate`:
+   - If `--date` provided: force-write the given date to ALL files (overrides any existing `CreateDate`)
+   - Otherwise: fill missing `CreateDate` using fallback chain (see below) — writes to the file-type-appropriate tag
+3. Skip renaming for files whose filename already matches `YYYYMMDD_HHMMSS*.ext` and have a valid `CreateDate` (EXIF backfill in step 2 still applies). When `--date` is used, all files are renamed (no skip).
 4. Rename remaining files to `YYYYMMDD_HHMMSS%-c.ext` based on resolved `CreateDate`
 
 **Date fallback chain:**
@@ -48,6 +50,7 @@ media-normalize [OPTIONS] [DIRECTORY]
 |---|---|
 | `--dry-run` | Preview changes without modifying files |
 | `--recursive` | Process subdirectories |
+| `--date "YYYY-MM-DD HH:MM:SS"` | Force-set `CreateDate` on all files, bypassing the fallback chain. The oldest file (by mtime) gets this exact date; other files are offset relative to the oldest, preserving their time differences. Useful for digitized photos, video frame exports, or any files with wrong/missing dates. |
 | (no flag) | Process only top-level files in directory |
 
 - `DIRECTORY` defaults to `.`

--- a/modules/home/media/tools/default.nix
+++ b/modules/home/media/tools/default.nix
@@ -13,7 +13,9 @@ in
 {
   options.${namespace}.media.tools = {
     enable = mkBoolOpt false "Media management CLI tools (media-normalize, media-import)";
-    mediaHome = mkOpt types.str "${config.home.homeDirectory}/Pictures/Photo" "Root directory for media library";
+    mediaHome =
+      mkOpt types.str "${config.home.homeDirectory}/Pictures/Photo"
+        "Root directory for media library";
   };
 
   config = mkIf cfg.enable {

--- a/modules/home/media/tools/default.nix
+++ b/modules/home/media/tools/default.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  namespace,
+  ...
+}:
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.media.tools;
+in
+{
+  options.${namespace}.media.tools = {
+    enable = mkBoolOpt false "Media management CLI tools (media-normalize, media-import)";
+    mediaHome = mkOpt types.str "${config.home.homeDirectory}/Pictures/Photo" "Root directory for media library";
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [ pkgs.${namespace}.media-tools ];
+    home.sessionVariables.MEDIA_HOME = cfg.mediaHome;
+  };
+}

--- a/modules/home/roles/media/default.nix
+++ b/modules/home/roles/media/default.nix
@@ -18,6 +18,7 @@ in
     ${namespace}.media = {
       players.vlc = enabled;
       shotwell = enabled;
+      tools = enabled;
     };
   };
 }

--- a/packages/media-tools/default.nix
+++ b/packages/media-tools/default.nix
@@ -1,0 +1,45 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+let
+  runtimeDeps = with pkgs; [
+    exiftool
+    coreutils
+    findutils
+  ];
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "media-tools";
+  version = "1.0.0";
+  src = ./.;
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/media-tools
+
+    # Install shared lib
+    cp media-common.sh $out/lib/media-tools/
+
+    # Install scripts and wrap with runtime deps
+    for script in media-normalize media-import; do
+      cp "$script.sh" "$out/bin/$script"
+      chmod +x "$out/bin/$script"
+
+      # Patch source path to point to installed location
+      substituteInPlace "$out/bin/$script" \
+        --replace-fail 'SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"' \
+        'SCRIPT_DIR="${placeholder "out"}/lib/media-tools"'
+
+      wrapProgram "$out/bin/$script" \
+        --prefix PATH : ${lib.makeBinPath runtimeDeps}
+    done
+  '';
+
+  meta = with lib; {
+    description = "CLI tools for managing personal media files";
+    platforms = platforms.all;
+  };
+}

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTENSIONS="jpg jpeg png heic mp4 mov"
+FILENAME_FORMAT="%Y%m%d_%H%M%S%%-c.%%e"
+MIN_FILE_SIZE=30000  # 30KB - skip thumbnails/artifacts
+
+# Normalized filename pattern: YYYYMMDD_HHMMSS with optional -N suffix
+NORMALIZED_PATTERN='^[0-9]{8}_[0-9]{6}(-[0-9]+)?\.'
+
+# Filename date patterns for fallback parsing
+# Returns date string in "YYYY:MM:DD HH:MM:SS" exiftool format, or empty
+parse_date_from_filename() {
+  local filename
+  filename=$(basename "$1")
+  filename="${filename%.*}"  # strip extension
+
+  local date_str=""
+
+  # Try each pattern
+  if [[ "$filename" =~ ^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2}) ]]; then
+    date_str="${BASH_REMATCH[2]}:${BASH_REMATCH[3]}:${BASH_REMATCH[4]} ${BASH_REMATCH[5]}:${BASH_REMATCH[6]}:${BASH_REMATCH[7]}"
+  elif [[ "$filename" =~ ([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2}) ]]; then
+    date_str="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}:${BASH_REMATCH[3]} ${BASH_REMATCH[4]}:${BASH_REMATCH[5]}:${BASH_REMATCH[6]}"
+  fi
+
+  echo "$date_str"
+}
+
+# Build exiftool extension args: -ext jpg -ext jpeg -ext png ...
+exiftool_ext_args() {
+  local args=""
+  for ext in $EXTENSIONS; do
+    args="$args -ext $ext"
+  done
+  echo "$args"
+}
+
+# Print error to stderr
+print_error() {
+  echo "ERROR: $1" >&2
+}
+
+# Print info message
+print_info() {
+  echo ":: $1"
+}
+
+# Parse common flags. Sets DRY_RUN, RECURSIVE, and remaining args in POSITIONAL.
+# Tool-specific flags (e.g. --move) should be parsed before calling this.
+DRY_RUN=false
+RECURSIVE=false
+POSITIONAL=()
+
+parse_common_args() {
+  DRY_RUN=false
+  RECURSIVE=false
+  POSITIONAL=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)  DRY_RUN=true; shift ;;
+      --recursive) RECURSIVE=true; shift ;;
+      --help|-h)  usage; exit 0 ;;
+      -*)         print_error "Unknown option: $1"; usage; exit 1 ;;
+      *)          POSITIONAL+=("$1"); shift ;;
+    esac
+  done
+}
+
+# Exiftool maxdepth flag based on RECURSIVE
+exiftool_depth_args() {
+  if [[ "$RECURSIVE" == false ]]; then
+    echo "-maxdepth 0"
+  fi
+}

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -17,10 +17,13 @@ parse_date_from_filename() {
 
   local date_str=""
 
-  # Try each pattern
-  if [[ "$filename" =~ ^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2}) ]]; then
+  # Try each pattern (stored in variables to avoid bash 5.3 regex parsing issues with spaces in bracket expressions)
+  local re_prefixed='^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2})'
+  local re_dashed='([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2})'
+
+  if [[ "$filename" =~ $re_prefixed ]]; then
     date_str="${BASH_REMATCH[2]}:${BASH_REMATCH[3]}:${BASH_REMATCH[4]} ${BASH_REMATCH[5]}:${BASH_REMATCH[6]}:${BASH_REMATCH[7]}"
-  elif [[ "$filename" =~ ([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2}) ]]; then
+  elif [[ "$filename" =~ $re_dashed ]]; then
     date_str="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}:${BASH_REMATCH[3]} ${BASH_REMATCH[4]}:${BASH_REMATCH[5]}:${BASH_REMATCH[6]}"
   fi
 

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+MOVE=false
+
+usage() {
+  cat <<EOF
+Usage: media-import [OPTIONS] [SOURCE]
+
+Import media files into \$MEDIA_HOME/All/YYYY/MM/ structure.
+
+Options:
+  --dry-run     Preview changes without modifying files
+  --move        Move files instead of copy (default: copy)
+  --recursive   Process subdirectories
+  -h, --help    Show this help
+
+SOURCE defaults to current directory.
+Requires MEDIA_HOME environment variable.
+EOF
+}
+
+# Override parse_common_args to handle --move
+parse_args() {
+  local remaining=()
+  MOVE=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --move) MOVE=true; shift ;;
+      *)      remaining+=("$1"); shift ;;
+    esac
+  done
+
+  parse_common_args "${remaining[@]}"
+}
+
+# Main
+parse_args "$@"
+SRC="${POSITIONAL[0]:-.}"
+
+if [[ -z "${MEDIA_HOME:-}" ]]; then
+  print_error "MEDIA_HOME environment variable is not set."
+  print_error "Set it to your media library root (e.g., ~/Pictures/Photo)"
+  exit 1
+fi
+
+if [[ ! -d "$SRC" ]]; then
+  print_error "Source directory does not exist: $SRC"
+  exit 1
+fi
+
+DST="$MEDIA_HOME/All"
+mkdir -p "$DST"
+
+print_info "Importing media from: $SRC"
+print_info "Destination: $DST"
+[[ "$DRY_RUN" == true ]] && print_info "DRY RUN - no files will be modified"
+[[ "$MOVE" == true ]] && print_info "Mode: move" || print_info "Mode: copy"
+
+depth_args=$(exiftool_depth_args)
+dst_format="$DST/%Y/%m/$FILENAME_FORMAT"
+
+# Common exiftool args for selecting media files above size threshold
+# shellcheck disable=SC2086
+run_exiftool_import() {
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if "\$filesize# > $MIN_FILE_SIZE" \
+    "$@" \
+    "$SRC" 2>/dev/null || true
+}
+
+if [[ "$DRY_RUN" == true ]]; then
+  # Preview: use -p to print source -> destination mapping without copying
+  # shellcheck disable=SC2086
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if "\$filesize# > $MIN_FILE_SIZE" \
+    -p "\$filename -> $DST/\$DateTimeOriginal" \
+    -d "%Y/%m/%Y%m%d_%H%M%S.%le" \
+    "$SRC" 2>/dev/null || true
+elif [[ "$MOVE" == true ]]; then
+  # Collect matching source file paths before copying
+  mapfile -d '' src_files < <(
+    # shellcheck disable=SC2086
+    exiftool $depth_args $(exiftool_ext_args) \
+      -if "\$filesize# > $MIN_FILE_SIZE" \
+      -print0 "$SRC" 2>/dev/null || true
+  )
+
+  if [[ ${#src_files[@]} -eq 0 ]]; then
+    print_info "No files to import."
+  else
+    # Copy to destination (no || true — fail loudly on copy errors)
+    # shellcheck disable=SC2086
+    exiftool \
+      $depth_args \
+      $(exiftool_ext_args) \
+      -if "\$filesize# > $MIN_FILE_SIZE" \
+      -o "$dst_format" \
+      -d "$dst_format" \
+      -progress \
+      "$SRC"
+
+    # Delete source files after successful copy
+    for file in "${src_files[@]}"; do
+      rm -- "$file"
+      print_info "Removed source: $file"
+    done
+  fi
+else
+  # Copy mode
+  run_exiftool_import -o "$dst_format" -d "$dst_format" -progress
+fi
+
+print_info "Done."

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -39,6 +39,29 @@ parse_args() {
   parse_common_args "${remaining[@]}"
 }
 
+# Ensure all matching files have a CreateDate (fill from mtime if missing).
+# This is done in a temporary copy of metadata only — source files are NOT modified.
+# Exiftool's -o with date format skips files without CreateDate, so we need this.
+fill_missing_dates_for_import() {
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    while IFS= read -r -d '' file; do
+      local create_date
+      create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+
+      if [[ -z "$create_date" || "$create_date" == "0000:00:00 00:00:00" ]]; then
+        if [[ "$DRY_RUN" == false ]]; then
+          exiftool -overwrite_original '-CreateDate<FileModifyDate' "$file" 2>/dev/null || true
+        fi
+      fi
+    done < <(find "$SRC" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
+  done
+}
+
 # Main
 parse_args "$@"
 SRC="${POSITIONAL[0]:-.}"
@@ -83,10 +106,13 @@ if [[ "$DRY_RUN" == true ]]; then
     $depth_args \
     $(exiftool_ext_args) \
     -if "\$filesize# > $MIN_FILE_SIZE" \
-    -p "\$filename -> $DST/\$DateTimeOriginal" \
+    -p "\$filename -> $DST/\$CreateDate" \
     -d "%Y/%m/%Y%m%d_%H%M%S.%le" \
     "$SRC" 2>/dev/null || true
 elif [[ "$MOVE" == true ]]; then
+  # Fill missing CreateDate from mtime so exiftool -o can resolve all files
+  fill_missing_dates_for_import
+
   # Collect matching source file paths before copying
   mapfile -d '' src_files < <(
     # shellcheck disable=SC2086
@@ -116,6 +142,9 @@ elif [[ "$MOVE" == true ]]; then
     done
   fi
 else
+  # Fill missing CreateDate from mtime so exiftool -o can resolve all files
+  fill_missing_dates_for_import
+
   # Copy mode
   run_exiftool_import -o "$dst_format" -d "$dst_format" -progress
 fi

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=media-common.sh
 source "$SCRIPT_DIR/media-common.sh"
 
+FORCE_DATE=""
+
 usage() {
   cat <<EOF
 Usage: media-normalize [OPTIONS] [DIRECTORY]
@@ -17,12 +19,37 @@ Steps:
   3. Rename files to YYYYMMDD_HHMMSS format
 
 Options:
-  --dry-run     Preview changes without modifying files
-  --recursive   Process subdirectories
-  -h, --help    Show this help
+  --dry-run                       Preview changes without modifying files
+  --recursive                     Process subdirectories
+  --date "YYYY-MM-DD HH:MM:SS"   Force-set CreateDate on ALL files.
+                                  The oldest file (by mtime) gets this exact date.
+                                  Other files are offset relative to the oldest,
+                                  preserving their time differences.
+  -h, --help                      Show this help
 
 DIRECTORY defaults to current directory.
 EOF
+}
+
+# Parse --date before common args
+parse_args() {
+  local remaining=()
+  FORCE_DATE=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --date)
+        if [[ $# -lt 2 ]]; then
+          print_error "--date requires a value (e.g., --date \"2023-01-15 14:30:00\")"
+          exit 1
+        fi
+        FORCE_DATE="$2"; shift 2 ;;
+      *)
+        remaining+=("$1"); shift ;;
+    esac
+  done
+
+  parse_common_args "${remaining[@]}"
 }
 
 # Step 1: Lowercase extensions
@@ -36,7 +63,6 @@ lowercase_extensions() {
   for ext in $EXTENSIONS; do
     local EXT
     EXT=$(echo "$ext" | tr '[:lower:]' '[:upper:]')
-    # Find files with uppercase extension
     while IFS= read -r -d '' file; do
       local newfile="${file%."$EXT"}.$ext"
       if [[ "$DRY_RUN" == true ]]; then
@@ -49,7 +75,74 @@ lowercase_extensions() {
   done
 }
 
-# Step 2: Fill missing EXIF CreateDate
+# Collect all matching media files
+collect_media_files() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null
+  done
+}
+
+# Step 2: Set EXIF CreateDate
+set_dates() {
+  local dir="$1"
+
+  if [[ -n "$FORCE_DATE" ]]; then
+    force_set_dates "$dir"
+  else
+    fill_missing_dates "$dir"
+  fi
+}
+
+# --date mode: force-set date with relative offsets from oldest file
+force_set_dates() {
+  local dir="$1"
+  local formatted_date
+  formatted_date=$(echo "$FORCE_DATE" | sed 's/-/:/g; s/\//:/g')
+  local base_epoch
+  base_epoch=$(date -j -f "%Y:%m:%d %H:%M:%S" "$formatted_date" "+%s" 2>/dev/null || \
+               date -d "${FORCE_DATE}" "+%s" 2>/dev/null)
+
+  # Find the oldest file by mtime
+  local oldest_mtime=""
+  while IFS= read -r -d '' file; do
+    local mtime
+    mtime=$(stat -f "%m" "$file" 2>/dev/null || stat -c "%Y" "$file" 2>/dev/null)
+    if [[ -z "$oldest_mtime" || "$mtime" -lt "$oldest_mtime" ]]; then
+      oldest_mtime="$mtime"
+    fi
+  done < <(collect_media_files "$dir")
+
+  if [[ -z "$oldest_mtime" ]]; then
+    print_info "No media files found."
+    return
+  fi
+
+  # Set each file's date as base_date + (file_mtime - oldest_mtime)
+  while IFS= read -r -d '' file; do
+    local mtime
+    mtime=$(stat -f "%m" "$file" 2>/dev/null || stat -c "%Y" "$file" 2>/dev/null)
+    local offset=$(( mtime - oldest_mtime ))
+    local target_epoch=$(( base_epoch + offset ))
+    local target_date
+    target_date=$(date -j -f "%s" "$target_epoch" "+%Y:%m:%d %H:%M:%S" 2>/dev/null || \
+                  date -d "@${target_epoch}" "+%Y:%m:%d %H:%M:%S" 2>/dev/null)
+
+    if [[ "$DRY_RUN" == true ]]; then
+      print_info "[dry-run] Force CreateDate: $file -> $target_date (offset: ${offset}s)"
+    else
+      exiftool -overwrite_original -CreateDate="$target_date" "$file"
+      print_info "Force CreateDate: $file -> $target_date (offset: ${offset}s)"
+    fi
+  done < <(collect_media_files "$dir")
+}
+
+# Fallback chain mode: fill missing dates only
 fill_missing_dates() {
   local dir="$1"
   local find_depth=("-maxdepth" "1")
@@ -59,12 +152,11 @@ fill_missing_dates() {
 
   for ext in $EXTENSIONS; do
     while IFS= read -r -d '' file; do
-      # Check if CreateDate exists and is valid
       local create_date
       create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
 
       if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
-        continue  # already has valid date
+        continue
       fi
 
       # Fallback 1: parse from filename
@@ -98,8 +190,6 @@ rename_files() {
   local depth_args
   depth_args=$(exiftool_depth_args)
 
-  # Skip files already matching the normalized pattern
-  # exiftool -if condition skips files whose basename matches YYYYMMDD_HHMMSS
   local dry_run_flag=""
   if [[ "$DRY_RUN" == true ]]; then
     dry_run_flag="-testname"
@@ -107,11 +197,18 @@ rename_files() {
     dry_run_flag="-filename"
   fi
 
+  # When --date is used, rename all files (no skip)
+  # Otherwise, skip files already matching the normalized pattern
+  local if_args=()
+  if [[ -z "$FORCE_DATE" ]]; then
+    if_args=(-if 'not ($filename =~ /^[0-9]{8}_[0-9]{6}/)')
+  fi
+
   # shellcheck disable=SC2086
   exiftool \
     $depth_args \
     $(exiftool_ext_args) \
-    -if 'not ($filename =~ /^[0-9]{8}_[0-9]{6}/)' \
+    "${if_args[@]}" \
     "${dry_run_flag}<CreateDate" \
     -d "$FILENAME_FORMAT" \
     -overwrite_original \
@@ -119,7 +216,7 @@ rename_files() {
 }
 
 # Main
-parse_common_args "$@"
+parse_args "$@"
 DIR="${POSITIONAL[0]:-.}"
 
 if [[ ! -d "$DIR" ]]; then
@@ -129,9 +226,10 @@ fi
 
 print_info "Normalizing media in: $DIR"
 [[ "$DRY_RUN" == true ]] && print_info "DRY RUN - no files will be modified"
+[[ -n "$FORCE_DATE" ]] && print_info "Force date: $FORCE_DATE (base for oldest file, others offset by mtime)"
 
 lowercase_extensions "$DIR"
-fill_missing_dates "$DIR"
+set_dates "$DIR"
 rename_files "$DIR"
 
 print_info "Done."

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -105,14 +105,14 @@ force_set_dates() {
   local formatted_date
   formatted_date=$(echo "$FORCE_DATE" | sed 's/-/:/g; s/\//:/g')
   local base_epoch
-  base_epoch=$(date -j -f "%Y:%m:%d %H:%M:%S" "$formatted_date" "+%s" 2>/dev/null || \
-               date -d "${FORCE_DATE}" "+%s" 2>/dev/null)
+  base_epoch=$(date -d "${FORCE_DATE}" "+%s" 2>/dev/null || \
+               date -j -f "%Y:%m:%d %H:%M:%S" "$formatted_date" "+%s" 2>/dev/null)
 
   # Find the oldest file by mtime
   local oldest_mtime=""
   while IFS= read -r -d '' file; do
     local mtime
-    mtime=$(stat -f "%m" "$file" 2>/dev/null || stat -c "%Y" "$file" 2>/dev/null)
+    mtime=$(stat -c "%Y" "$file" 2>/dev/null || stat -f "%m" "$file" 2>/dev/null)
     if [[ -z "$oldest_mtime" || "$mtime" -lt "$oldest_mtime" ]]; then
       oldest_mtime="$mtime"
     fi
@@ -126,12 +126,12 @@ force_set_dates() {
   # Set each file's date as base_date + (file_mtime - oldest_mtime)
   while IFS= read -r -d '' file; do
     local mtime
-    mtime=$(stat -f "%m" "$file" 2>/dev/null || stat -c "%Y" "$file" 2>/dev/null)
+    mtime=$(stat -c "%Y" "$file" 2>/dev/null || stat -f "%m" "$file" 2>/dev/null)
     local offset=$(( mtime - oldest_mtime ))
     local target_epoch=$(( base_epoch + offset ))
     local target_date
-    target_date=$(date -j -f "%s" "$target_epoch" "+%Y:%m:%d %H:%M:%S" 2>/dev/null || \
-                  date -d "@${target_epoch}" "+%Y:%m:%d %H:%M:%S" 2>/dev/null)
+    target_date=$(date -d "@${target_epoch}" "+%Y:%m:%d %H:%M:%S" 2>/dev/null || \
+                  date -j -f "%s" "$target_epoch" "+%Y:%m:%d %H:%M:%S" 2>/dev/null)
 
     if [[ "$DRY_RUN" == true ]]; then
       print_info "[dry-run] Force CreateDate: $file -> $target_date (offset: ${offset}s)"

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+usage() {
+  cat <<EOF
+Usage: media-normalize [OPTIONS] [DIRECTORY]
+
+Normalize media filenames and EXIF metadata in-place.
+
+Steps:
+  1. Lowercase file extensions
+  2. Fill missing EXIF CreateDate (from filename or mtime)
+  3. Rename files to YYYYMMDD_HHMMSS format
+
+Options:
+  --dry-run     Preview changes without modifying files
+  --recursive   Process subdirectories
+  -h, --help    Show this help
+
+DIRECTORY defaults to current directory.
+EOF
+}
+
+# Step 1: Lowercase extensions
+lowercase_extensions() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    local EXT
+    EXT=$(echo "$ext" | tr '[:lower:]' '[:upper:]')
+    # Find files with uppercase extension
+    while IFS= read -r -d '' file; do
+      local newfile="${file%."$EXT"}.$ext"
+      if [[ "$DRY_RUN" == true ]]; then
+        print_info "[dry-run] Rename: $file -> $newfile"
+      else
+        mv -- "$file" "$newfile"
+        print_info "Renamed: $file -> $newfile"
+      fi
+    done < <(find "$dir" "${find_depth[@]}" -name "*.$EXT" -type f -print0 2>/dev/null)
+  done
+}
+
+# Step 2: Fill missing EXIF CreateDate
+fill_missing_dates() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  for ext in $EXTENSIONS; do
+    while IFS= read -r -d '' file; do
+      # Check if CreateDate exists and is valid
+      local create_date
+      create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+
+      if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
+        continue  # already has valid date
+      fi
+
+      # Fallback 1: parse from filename
+      local parsed_date
+      parsed_date=$(parse_date_from_filename "$file")
+
+      if [[ -n "$parsed_date" ]]; then
+        if [[ "$DRY_RUN" == true ]]; then
+          print_info "[dry-run] Set CreateDate from filename: $file -> $parsed_date"
+        else
+          exiftool -overwrite_original -CreateDate="$parsed_date" "$file"
+          print_info "Set CreateDate from filename: $file -> $parsed_date"
+        fi
+        continue
+      fi
+
+      # Fallback 2: file modification date
+      if [[ "$DRY_RUN" == true ]]; then
+        print_info "[dry-run] Set CreateDate from mtime: $file"
+      else
+        exiftool -overwrite_original '-CreateDate<FileModifyDate' "$file"
+        print_info "Set CreateDate from mtime: $file"
+      fi
+    done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
+  done
+}
+
+# Step 3: Rename files to canonical format
+rename_files() {
+  local dir="$1"
+  local depth_args
+  depth_args=$(exiftool_depth_args)
+
+  # Skip files already matching the normalized pattern
+  # exiftool -if condition skips files whose basename matches YYYYMMDD_HHMMSS
+  local dry_run_flag=""
+  if [[ "$DRY_RUN" == true ]]; then
+    dry_run_flag="-testname"
+  else
+    dry_run_flag="-filename"
+  fi
+
+  # shellcheck disable=SC2086
+  exiftool \
+    $depth_args \
+    $(exiftool_ext_args) \
+    -if 'not ($filename =~ /^[0-9]{8}_[0-9]{6}/)' \
+    "${dry_run_flag}<CreateDate" \
+    -d "$FILENAME_FORMAT" \
+    -overwrite_original \
+    "$dir" 2>/dev/null || true
+}
+
+# Main
+parse_common_args "$@"
+DIR="${POSITIONAL[0]:-.}"
+
+if [[ ! -d "$DIR" ]]; then
+  print_error "Directory does not exist: $DIR"
+  exit 1
+fi
+
+print_info "Normalizing media in: $DIR"
+[[ "$DRY_RUN" == true ]] && print_info "DRY RUN - no files will be modified"
+
+lowercase_extensions "$DIR"
+fill_missing_dates "$DIR"
+rename_files "$DIR"
+
+print_info "Done."


### PR DESCRIPTION
## Summary

- Add `media-normalize` CLI tool for normalizing media filenames and EXIF metadata in-place (lowercase extensions, fill missing CreateDate from filename/mtime, rename to `YYYYMMDD_HHMMSS` format)
- Add `media-import` CLI tool for organizing media files into `$MEDIA_HOME/All/YYYY/MM/` canonical folder structure with copy/move/dry-run support
- Add `--date` flag to `media-normalize` for force-setting CreateDate with relative mtime offsets (useful for digitized photos, video frame exports)
- Nix package at `packages/media-tools/` with wrapped runtime deps (exiftool, coreutils, findutils)
- Home-manager module at `modules/home/media/tools/` with `MEDIA_HOME` session variable config
- Integrated into the media role

Ported from [old dotfiles img plugin](https://github.com/aleks-sidorenko/dotfiles/blob/master/shell/plugins/img/img.plugin.zsh) with improved naming, separation of concerns, and consistent argument handling.

## Test plan

- [ ] `nix build .#media-tools` succeeds
- [ ] `media-normalize --help` and `media-import --help` show usage
- [ ] `media-normalize --dry-run <dir>` previews changes without modifying files
- [ ] `media-normalize --date "2023-01-15 14:30:00" --dry-run <dir>` shows offset dates
- [ ] `media-import --dry-run <dir>` previews import without copying
- [ ] `media-import` errors clearly when `MEDIA_HOME` is unset
- [ ] `nix flake check` passes