### PR TITLE
docs(claude-code): branch naming and PR conventions

### DIFF
--- a/modules/home/development/ai/claude-code/default.nix
+++ b/modules/home/development/ai/claude-code/default.nix
@@ -43,7 +43,7 @@ in
 
         ## Pull Requests
 
-        - PR title follows the same Conventional Commits format as commit messages
+        - PR title follows Conventional Commits format, reflecting the primary goal of the work
         - PR branch should be based off `master`
 
         ## Documentation Structure

--- a/modules/home/development/ai/claude-code/default.nix
+++ b/modules/home/development/ai/claude-code/default.nix
@@ -33,6 +33,19 @@ in
 
         Types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `style`, `ci`, `perf`, `build`. Use `!` or `BREAKING CHANGE:` footer for breaking changes.
 
+        ## Git Branches
+
+        Branch names MUST follow: `<type>/<short-description>`
+
+        - Name the branch after the primary goal of the work, not individual commits
+        - Use the same `type` prefixes as commits: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`, `perf/`, `build/`
+        - Use kebab-case for the description: `feat/add-wifi-module`, `fix/hyprland-crash`
+
+        ## Pull Requests
+
+        - PR title follows the same Conventional Commits format as commit messages
+        - PR branch should be based off `master`
+
         ## Documentation Structure
 
         - `docs/specs/` - Feature specifications and requirements


### PR DESCRIPTION
## Summary

- Add git branch naming conventions (`<type>/<short-description>`) to global Claude Code CLAUDE.md
- Add PR conventions (title format, base branch)
- Ensures consistent branch naming across all projects

## Test plan

- [ ] Verify `nh home switch` applies the updated CLAUDE.md
- [ ] Confirm Claude Code picks up the new conventions