### PR TITLE
fix(media-tools): fix date handling in import and normalize

### DIFF
--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -30,6 +30,28 @@ parse_date_from_filename() {
   echo "$date_str"
 }
 
+# Set DateTimeOriginal, CreateDate, and ModifyDate on a file.
+# Usage: set_all_dates <file> <date>        — set from literal date string
+#        set_all_dates <file> --from-mtime   — copy from FileModifyDate
+set_all_dates() {
+  local file="$1"
+  local date_or_flag="$2"
+
+  if [[ "$date_or_flag" == "--from-mtime" ]]; then
+    exiftool -overwrite_original \
+      '-DateTimeOriginal<FileModifyDate' \
+      '-CreateDate<FileModifyDate' \
+      '-ModifyDate<FileModifyDate' \
+      "$file"
+  else
+    exiftool -overwrite_original \
+      -DateTimeOriginal="$date_or_flag" \
+      -CreateDate="$date_or_flag" \
+      -ModifyDate="$date_or_flag" \
+      "$file"
+  fi
+}
+
 # Build exiftool extension args: -ext jpg -ext jpeg -ext png ...
 exiftool_ext_args() {
   local args=""

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -30,24 +30,47 @@ parse_date_from_filename() {
   echo "$date_str"
 }
 
-# Set DateTimeOriginal, CreateDate, and ModifyDate on a file.
-# Usage: set_all_dates <file> <date>        — set from literal date string
-#        set_all_dates <file> --from-mtime   — copy from FileModifyDate
+# Get timezone offset in +HH:MM format for a given epoch (or current time)
+# Usage: get_tz_offset [epoch]
+get_tz_offset() {
+  local raw
+  if [[ -n "${1:-}" ]]; then
+    raw=$(date -d "@$1" "+%z" 2>/dev/null || \
+          date -j -f "%s" "$1" "+%z" 2>/dev/null)
+  else
+    raw=$(date "+%z")
+  fi
+  # Convert +0300 to +03:00
+  echo "${raw:0:3}:${raw:3:2}"
+}
+
+# Set DateTimeOriginal, CreateDate, ModifyDate and timezone offset tags.
+# Usage: set_all_dates <file> <date> [tz_offset]  — set from literal date string
+#        set_all_dates <file> --from-mtime         — copy from FileModifyDate
 set_all_dates() {
   local file="$1"
   local date_or_flag="$2"
 
   if [[ "$date_or_flag" == "--from-mtime" ]]; then
+    local tz_offset
+    tz_offset=$(exiftool -s3 -d "%z" -FileModifyDate "$file" 2>/dev/null | sed 's/\(..\)$/:\1/')
     exiftool -overwrite_original \
       '-DateTimeOriginal<FileModifyDate' \
       '-CreateDate<FileModifyDate' \
       '-ModifyDate<FileModifyDate' \
+      -OffsetTimeOriginal="$tz_offset" \
+      -OffsetTimeDigitized="$tz_offset" \
+      -OffsetTime="$tz_offset" \
       "$file"
   else
+    local tz_offset="${3:-$(get_tz_offset)}"
     exiftool -overwrite_original \
       -DateTimeOriginal="$date_or_flag" \
       -CreateDate="$date_or_flag" \
       -ModifyDate="$date_or_flag" \
+      -OffsetTimeOriginal="$tz_offset" \
+      -OffsetTimeDigitized="$tz_offset" \
+      -OffsetTime="$tz_offset" \
       "$file"
   fi
 }

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -55,7 +55,7 @@ fill_missing_dates_for_import() {
 
       if [[ -z "$create_date" || "$create_date" == "0000:00:00 00:00:00" ]]; then
         if [[ "$DRY_RUN" == false ]]; then
-          exiftool -overwrite_original '-CreateDate<FileModifyDate' "$file" 2>/dev/null || true
+          set_all_dates "$file" --from-mtime 2>/dev/null || true
         fi
       fi
     done < <(find "$SRC" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -86,7 +86,7 @@ print_info "Destination: $DST"
 [[ "$MOVE" == true ]] && print_info "Mode: move" || print_info "Mode: copy"
 
 depth_args=$(exiftool_depth_args)
-dst_format="$DST/%Y/%m/$FILENAME_FORMAT"
+date_format="$DST/%Y/%m/$FILENAME_FORMAT"
 
 # Common exiftool args for selecting media files above size threshold
 # shellcheck disable=SC2086
@@ -130,8 +130,9 @@ elif [[ "$MOVE" == true ]]; then
       $depth_args \
       $(exiftool_ext_args) \
       -if "\$filesize# > $MIN_FILE_SIZE" \
-      -o "$dst_format" \
-      -d "$dst_format" \
+      -o . \
+      "-FileName<CreateDate" \
+      -d "$date_format" \
       -progress \
       "$SRC"
 
@@ -146,7 +147,7 @@ else
   fill_missing_dates_for_import
 
   # Copy mode
-  run_exiftool_import -o "$dst_format" -d "$dst_format" -progress
+  run_exiftool_import -o . "-FileName<CreateDate" -d "$date_format" -progress
 fi
 
 print_info "Done."

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -136,7 +136,7 @@ force_set_dates() {
     if [[ "$DRY_RUN" == true ]]; then
       print_info "[dry-run] Force CreateDate: $file -> $target_date (offset: ${offset}s)"
     else
-      exiftool -overwrite_original -CreateDate="$target_date" "$file"
+      set_all_dates "$file" "$target_date"
       print_info "Force CreateDate: $file -> $target_date (offset: ${offset}s)"
     fi
   done < <(collect_media_files "$dir")
@@ -165,20 +165,20 @@ fill_missing_dates() {
 
       if [[ -n "$parsed_date" ]]; then
         if [[ "$DRY_RUN" == true ]]; then
-          print_info "[dry-run] Set CreateDate from filename: $file -> $parsed_date"
+          print_info "[dry-run] Set date from filename: $file -> $parsed_date"
         else
-          exiftool -overwrite_original -CreateDate="$parsed_date" "$file"
-          print_info "Set CreateDate from filename: $file -> $parsed_date"
+          set_all_dates "$file" "$parsed_date"
+          print_info "Set date from filename: $file -> $parsed_date"
         fi
         continue
       fi
 
       # Fallback 2: file modification date
       if [[ "$DRY_RUN" == true ]]; then
-        print_info "[dry-run] Set CreateDate from mtime: $file"
+        print_info "[dry-run] Set date from mtime: $file"
       else
-        exiftool -overwrite_original '-CreateDate<FileModifyDate' "$file"
-        print_info "Set CreateDate from mtime: $file"
+        set_all_dates "$file" --from-mtime
+        print_info "Set date from mtime: $file"
       fi
     done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
   done

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -136,7 +136,7 @@ force_set_dates() {
     if [[ "$DRY_RUN" == true ]]; then
       print_info "[dry-run] Force CreateDate: $file -> $target_date (offset: ${offset}s)"
     else
-      set_all_dates "$file" "$target_date"
+      set_all_dates "$file" "$target_date" "$(get_tz_offset "$target_epoch")"
       print_info "Force CreateDate: $file -> $target_date (offset: ${offset}s)"
     fi
   done < <(collect_media_files "$dir")


### PR DESCRIPTION
## Summary
- Fix media-import date path resolution: exiftool's `-o` doesn't support strftime codes, switch to `-o . -FileName<CreateDate -d FORMAT` pattern
- Set all EXIF date tags (DateTimeOriginal, CreateDate, ModifyDate) instead of just CreateDate for Google Photos compatibility
- Write OffsetTime* timezone tags so Google Photos doesn't assume UTC and shift displayed times
- Extract `set_all_dates` and `get_tz_offset` helpers into media-common.sh (DRY)

## Test plan
- [ ] `media-import --dry-run` shows correct `YYYY/MM/` paths
- [ ] `media-import` copies files to correct date-based directories
- [ ] `media-import --move` moves files correctly
- [ ] `media-normalize --date "YYYY-MM-DD HH:MM:SS"` sets all 6 EXIF tags (3 dates + 3 offsets)
- [ ] `media-normalize` without --date fills missing dates with all tags
- [ ] Google Photos displays correct date after import