### PR TITLE
refactor(justfile): align core verb semantics across projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,14 +30,16 @@ just deploy vm --remote-build --verbose
 
 ```bash
 # Code quality
-just lint                  # Format, statix check, deadnix check
-just lint-fix              # Auto-fix issues (format, statix, deadnix)
-just lint-check            # Check without changes (CI-friendly)
-just format [path]         # Format nix files with nixfmt-tree
+just lint                  # Lint with statix + deadnix (read-only)
+just lint-fix              # Auto-fix lint issues (statix + deadnix)
+just format [path]         # Format nix files with nixfmt-tree (writes)
+just format-check          # Verify formatting (read-only)
+just check                 # CI-safe umbrella: format-check + lint
 
 # Build validation
-just build-test            # Test build without switching
-just check                 # Check flake for issues
+just build                 # Build configuration without switching (read-only)
+just switch                # Build and switch to new generation locally
+just flake-check           # nix flake check
 nix flake check            # Same as above
 
 # Bootstrap validation
@@ -252,8 +254,8 @@ IaC configurations in `infra/`:
 
 1. **Make changes** to modules or system configs
 2. **Format code**: `just format`
-3. **Validate**: `just lint-check`
-4. **Test build**: `just build-test` (local) or `nix flake check`
+3. **Validate**: `just check`
+4. **Test build**: `just build` (local) or `nix flake check`
 5. **Deploy**: `just deploy <hostname>` or `nh os switch` (local)
 6. **Commit**: Standard git workflow
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ To add a new host's key, see [docs/bootstrap.md](docs/bootstrap.md#adding-a-new-
 ```bash
 just update                                # Update flake inputs
 just cleanup                               # Garbage collect old generations
-just lint                                  # Format + statix + deadnix
+just lint                                  # statix + deadnix (read-only)
 just lint-fix                              # Auto-fix linting issues
-just check                                 # nix flake check
+just flake-check                           # nix flake check
 just info                                  # Show system info
 just disk-usage                            # Show nix store usage
 ```
@@ -144,8 +144,8 @@ just disk-usage                            # Show nix store usage
 ```bash
 # Typical workflow
 just format                                # Format nix files
-just lint-check                            # Verify code quality (CI-friendly)
-just build-test                            # Test build without switching
+just check                                 # Verify code quality (CI-friendly)
+just build                                 # Test build without switching
 just deploy <hostname>                     # Deploy
 ```
 

--- a/justfile
+++ b/justfile
@@ -92,15 +92,15 @@ deploy hostname *extra_opts="":
     fi
 
 
-# Build and switch to a new generation locally (for testing)
-build-local:
-    @echo "🔨 Building local configuration..."
-    sudo nixos-rebuild switch --flake .
-
-# Build without switching (dry-run)
-build-test:
-    @echo "🧪 Testing build configuration..."
+# Build configuration without switching (read-only artifact)
+build:
+    @echo "🔨 Building configuration..."
     nixos-rebuild build --flake .
+
+# Build and switch to a new generation locally (mutates system)
+switch:
+    @echo "🚀 Switching to new generation locally..."
+    sudo nixos-rebuild switch --flake .
 
 # Update flake inputs (optionally a single input)
 update *input:
@@ -108,7 +108,7 @@ update *input:
     nix flake update {{ input }}
 
 # Check flake for issues
-check:
+flake-check:
     @echo "🔍 Checking flake configuration..."
     nix flake check
 
@@ -148,43 +148,35 @@ cleanup:
     @echo "🗑️  Removing old boot entries..."
     sudo /run/current-system/bin/switch-to-configuration boot
 
-# Format nix files with nixfmt-tree (default formatter)
+# Format nix files with nixfmt-tree (writes)
 format *path=".":
     @echo "✨ Formatting nix files with nixfmt-tree..."
     nix fmt {{path}}
 
-# Run all code quality checks (format, lint, dead code detection)
+# Check formatting without modifying files (read-only)
+format-check:
+    @echo "🔍 Checking nix file formatting..."
+    nix fmt -- --fail-on-change
+
+# Lint with statix and deadnix (read-only)
 lint:
-    @echo "🔍 Running comprehensive code quality checks..."
-    @echo "📝 Formatting nix files..."
-    just format
     @echo "🕵️  Checking for issues with statix..."
     statix check .
     @echo "💀 Checking for dead code with deadnix..."
     deadnix --fail .
-    @echo "✅ All quality checks passed!"
+    @echo "✅ Lint passed!"
 
-# Fix common nix issues automatically
+# Auto-fix lint issues (statix fix + deadnix --edit)
 lint-fix:
-    @echo "🔧 Auto-fixing nix issues..."
-    @echo "📝 Formatting nix files..."
-    just format
     @echo "🔧 Auto-fixing statix issues..."
     statix fix .
     @echo "💀 Removing dead code..."
     deadnix --edit .
-    @echo "✅ Auto-fixes completed!"
+    @echo "✅ Lint fixes applied!"
 
-# Check code quality without making changes
-lint-check:
-    @echo "🔍 Checking code quality (no changes)..."
-    @echo "🔍 Checking nix file formatting..."
-    nix fmt -- --fail-on-change
-    @echo "🕵️  Checking for issues with statix..."
-    statix check .
-    @echo "💀 Checking for dead code with deadnix..."
-    deadnix --fail .
-    @echo "✅ Quality check passed!"
+# Read-only quality umbrella: format-check + lint (CI-safe)
+check: format-check lint
+    @echo "✅ All quality checks passed!"
 
 # Show secrets managed by SOPS
 secrets-list:


### PR DESCRIPTION
## Summary
- Make `lint` read-only and `lint-fix` write (was mixed: previous `lint` also formatted)
- Add `format-check`; `check` becomes the read-only quality umbrella (`format-check + lint`)
- Rename `build-test` → `build`, `build-local` → `switch`, old `check` (= `nix flake check`) → `flake-check`
- Update CLAUDE.md and README.md to reflect renames

Part of a coordinated alignment across nix-config + homeaccounting/{backend,web,infra} so common dev verbs (`format`, `format-check`, `lint`, `lint-fix`, `check`) behave consistently across repos.

## Test plan
- [ ] `just --list` shows expected recipes (`build`, `switch`, `flake-check`, `format-check`, `lint`, `lint-fix`, `check`)
- [ ] `just check` runs `format-check + lint` cleanly inside `nix develop`
- [ ] `just build` does `nixos-rebuild build` (no system mutation)
- [ ] `just switch` does `sudo nixos-rebuild switch`
- [ ] `just flake-check` runs `nix flake check`
- [ ] CI passes