### PR TITLE
feat(home/platforms): add node platform module

### DIFF
--- a/modules/home/development/platforms/node/default.nix
+++ b/modules/home/development/platforms/node/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  pkgs,
+  config,
+  namespace,
+  ...
+}:
+with lib;
+with lib.${namespace};
+let
+  cfg = config.${namespace}.development.platforms.node;
+  nodejs = if cfg.version == "20" then pkgs.nodejs_20 else pkgs.nodejs_22;
+in
+{
+  options.${namespace}.development.platforms.node = {
+    enable = mkEnableOption "Whether or not to enable Node.js platform";
+    version = mkStringOpt "22" "Node.js major version (20 or 22)";
+  };
+
+  config = mkIf cfg.enable {
+    home.sessionVariables = {
+      NPM_CONFIG_PREFIX = "${config.home.homeDirectory}/.npm-global";
+    };
+
+    home.sessionPath = [ "${config.home.homeDirectory}/.npm-global/bin" ];
+
+    home.packages = [ nodejs ];
+  };
+}

--- a/modules/home/roles/development/default.nix
+++ b/modules/home/roles/development/default.nix
@@ -36,6 +36,7 @@ in
 
     platforms = {
       jvm = mkEnableOption "Enable JVM platform support";
+      node = mkEnableOption "Enable Node.js platform support";
     };
 
     editors = {
@@ -71,6 +72,7 @@ in
         };
         platforms = {
           jvm.enable = cfg.platforms.jvm || cfg.languages.java || cfg.languages.scala;
+          node.enable = cfg.platforms.node || cfg.languages.typescript;
         };
         editors = {
           code = {

--- a/modules/home/roles/work/default.nix
+++ b/modules/home/roles/work/default.nix
@@ -37,6 +37,7 @@ in
             scala = true;
             java = true;
             haskell = true;
+            typescript = true;
           };
           editors = {
             cursor = true;


### PR DESCRIPTION
Mirrors the jvm platform module: exposes platforms.node with version toggle (20/22, default 22), installs pkgs.nodejs, and sets NPM_CONFIG_PREFIX so global npm installs land in ~/.npm-global.

The development role auto-enables it when languages.typescript is set, parallel to jvm auto-enabling on java/scala. Workbook opts in via languages.typescript = true.