### PR TITLE
fix(home/gpg): use GUI pinentry on graphical hosts for sops-nix

### DIFF
--- a/modules/home/security/gpg/default.nix
+++ b/modules/home/security/gpg/default.nix
@@ -45,7 +45,16 @@ in
       defaultCacheTtlSsh = cfg.cacheTtl;
       maxCacheTtl = cfg.cacheTtl;
       maxCacheTtlSsh = cfg.cacheTtl;
-      pinentry.package = if config.gtk.enable then pkgs.pinentry-gnome3 else pkgs.pinentry-curses;
+      # sops-nix decryption runs without a TTY (systemd user service on Linux,
+      # launchd agent on darwin), so a terminal pinentry can never prompt there.
+      # Use a GUI pinentry on graphical hosts; fall back to curses for headless.
+      pinentry.package =
+        if pkgs.stdenv.isDarwin then
+          pkgs.pinentry_mac
+        else if config.gtk.enable then
+          pkgs.pinentry-gnome3
+        else
+          pkgs.pinentry-curses;
       extraConfig = ''
         allow-preset-passphrase
         ttyname $GPG_TTY

--- a/modules/home/security/gpg/default.nix
+++ b/modules/home/security/gpg/default.nix
@@ -45,7 +45,7 @@ in
       defaultCacheTtlSsh = cfg.cacheTtl;
       maxCacheTtl = cfg.cacheTtl;
       maxCacheTtlSsh = cfg.cacheTtl;
-      pinentry.package = pkgs.pinentry-curses;
+      pinentry.package = if config.gtk.enable then pkgs.pinentry-gnome3 else pkgs.pinentry-curses;
       extraConfig = ''
         allow-preset-passphrase
         ttyname $GPG_TTY

--- a/modules/home/security/sops/default.nix
+++ b/modules/home/security/sops/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   inputs,
   namespace,
   ...
@@ -30,6 +31,19 @@ in
 
       defaultSymlinkPath = "${secretsBase}/secrets";
       defaultSecretsMountPoint = "${secretsBase}/secrets.d";
+    };
+
+    # On Linux, sops-nix decrypts inside a TTY-less systemd user service. With a
+    # GnuPG key it defaults to graphical-session-pre.target, which can run before
+    # the session environment (WAYLAND_DISPLAY) is imported, so gpg-agent has no
+    # display to spawn a GUI pinentry on. Order it after graphical-session.target
+    # so the first gpg-agent activation inherits the imported session env.
+    systemd.user.services.sops-nix = mkIf (pkgs.stdenv.isLinux && config.gtk.enable) {
+      Unit = {
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Install.WantedBy = mkForce [ "graphical-session.target" ];
     };
   };
 }


### PR DESCRIPTION
## Problem

On the desktop, `nh home switch` from a fresh TTY fails on sops and `sops-nix.service` never loads secrets — unless a sops file was edited (passphrase entered) earlier in the session.

## Root cause

home-manager's sops-nix decryption on Linux runs in a **TTY-less systemd user service** (`sops-nix.service`), not in the foreground of `nh home switch`. With `pinentry-curses`, there's no terminal to draw the passphrase prompt, so GPG decryption **silently fails** when gpg-agent has no cached passphrase.

Editing a sops file in a terminal works around it because `pinentry-curses` *can* draw there, and gpg-agent then caches the passphrase (`cacheTtl` = 24h) for subsequent non-interactive service runs.

## Fix

Use `pinentry-gnome3` when `config.gtk.enable` (graphical hosts), else keep `pinentry-curses` (headless/TTY hosts). pinentry is spawned by **gpg-agent**, which holds the GNOME session environment, so the GUI prompt renders regardless of the service having no TTY. Keeps GPG as the single secret root — no age key / second secret introduced.

## Tradeoffs

- Still one GUI prompt per cache window (24h) when the key isn't cached — but it now *appears* instead of silently failing.
- Ordering edge case at login/boot if gpg-agent starts before the session env import; can be addressed later with `graphical-session.target` ordering if it surfaces.

## Validation

1. `nh home switch` on the desktop from a fresh TTY with no prior `sops` use → GNOME passphrase dialog appears (was a silent failure).
2. `systemctl --user status sops-nix` active; a secret resolves (e.g. `~/.local/share/sops-nix/secrets/gh-token`).