### PR TITLE
fix(home/gh): don't force GH_TOKEN so gh uses keyring OAuth for SSO orgs

### DIFF
--- a/modules/home/roles/development/default.nix
+++ b/modules/home/roles/development/default.nix
@@ -137,10 +137,11 @@ in
           direnv.enable = true;
           eza.enable = true;
           fzf.enable = true;
-          gh = {
-            enable = true;
-            githubToken = true;
-          };
+          # githubToken (GH_TOKEN) left off: GH_TOKEN shadows the keyring OAuth
+          # login, and the classic PAT it carries is rejected by SSO orgs.
+          # Interactive machines use `gh auth login` instead.
+          # Enable githubToken per-host on headless servers that have no keyring.
+          gh.enable = true;
           git.enable = true;
           htop.enable = true;
           modern-unix.enable = true;


### PR DESCRIPTION
GH_TOKEN shadows the keyring OAuth login, and the classic PAT it carried is rejected by SSO orgs. Drop githubToken from the development role so interactive machines authenticate via `gh auth login` instead. The githubToken option remains available for opt-in on headless hosts.