### PR TITLE
feat(media-tools): recover Telegram post dates + add media-info inspector

### DIFF
--- a/docs/superpowers/plans/2026-06-29-media-tools-telegram-date.md
+++ b/docs/superpowers/plans/2026-06-29-media-tools-telegram-date.md
@@ -435,16 +435,16 @@ git commit -m "fix(media-tools): import recovers telegram post dates via shared 
 
 - [ ] **Step 1: Write the failing integration test**
 
-Add to `run-tests.sh` (inside the `if [[ -f "$PHOTO" ... ]]` block from Task 3, or a new guarded block):
+Add to `run-tests.sh` **inside the existing `if [[ -f "$PHOTO" && -f "$VIDEO" ]]` block from Task 3** (do NOT open a new block — `$WORK` and the copied fixtures are defined only inside that block; a separate `if` would leave `$WORK` unbound and fail under `set -u`):
 
 ```bash
-if [[ -f "$PHOTO" ]]; then
+  # (these lines go inside Task 3's `if [[ -f "$PHOTO" && -f "$VIDEO" ]]` block,
+  #  after the resolve_date assertions, so $WORK is in scope)
   info_out="$(bash "$LIB_DIR/media-info.sh" "$WORK/photo_455@21-06-2026_15-17-04.jpg")"
   assert_eq "media-info resolved source is filename" \
     "1" "$(grep -c 'source: filename' <<<"$info_out")"
   assert_eq "media-info would-become name is post date" \
     "1" "$(grep -c '20260621_151704.jpg' <<<"$info_out")"
-fi
 ```
 
 - [ ] **Step 2: Run to verify failure**
@@ -563,7 +563,7 @@ The existing `substituteInPlace` (SCRIPT_DIR patch) and `wrapProgram` (PATH pref
 
 - [ ] **Step 2: Build the package**
 
-Run: `nix build .#media-tools` (or the appropriate attr — discover via `nix eval --json .#packages.aarch64-darwin --apply builtins.attrNames 2>/dev/null` or check how the package is referenced in the flake; fall back to `nix-build` on the derivation if needed).
+Run: `nix build .#packages.aarch64-darwin.media-tools` (the package is snowfall-namespaced; the bare `.#media-tools` attr will NOT resolve). If the attr path differs, discover it via `nix eval --json .#packages.aarch64-darwin --apply builtins.attrNames 2>/dev/null`.
 Expected: build succeeds; `result/bin/` contains `media-info`, `media-normalize`, `media-import`.
 
 - [ ] **Step 3: Run the wrapped binary (deps on PATH, no nix shell needed)**

--- a/docs/superpowers/plans/2026-06-29-media-tools-telegram-date.md
+++ b/docs/superpowers/plans/2026-06-29-media-tools-telegram-date.md
@@ -1,0 +1,598 @@
+# media-tools Telegram Date Recovery + media-info Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover the Telegram post date from photo filenames during both normalize and import via a pluggable filename-pattern registry, and add a read-only `media-info <file>` inspector.
+
+**Architecture:** All shared logic lives in `media-common.sh`. Filename date parsing becomes a declarative registry (`FILENAME_DATE_PATTERNS`) consumed by a generic loop. A single `resolve_date` helper is the one authority for the EXIF→filename→mtime precedence; both the shared `fill_missing_dates` (used by `media-normalize` and `media-import`) and the new `media-info` build on it.
+
+**Tech Stack:** Bash 5.3, exiftool, coreutils/findutils, Nix (`stdenvNoCC.mkDerivation` + `makeWrapper`). Spec: `docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md`.
+
+---
+
+## Context for the implementer
+
+- The package is four files in `packages/media-tools/`: `media-common.sh` (shared lib, sourced by the tools), `media-normalize.sh`, `media-import.sh`, `default.nix` (installs + wraps each script with runtime deps on PATH).
+- `parse_date_from_filename` (media-common.sh:13-31) currently hardcodes two regexes in an `if/elif`. Each branch reassembles `BASH_REMATCH` in its own order. Output: `YYYY:MM:DD HH:MM:SS` string, or empty on no match.
+- `set_all_dates` (media-common.sh:50-76) writes DateTimeOriginal/CreateDate/ModifyDate + tz offsets, either from a literal date string or `--from-mtime`.
+- `media-normalize.sh`'s `fill_missing_dates` (lines 146-185) runs EXIF→filename→mtime. `media-import.sh`'s `fill_missing_dates_for_import` (lines 45-63) is **mtime-only** and has a stale comment claiming it doesn't modify sources (it does, via `set_all_dates ... -overwrite_original`).
+- **exiftool is NOT on PATH in this environment.** Run anything that needs it (tests, manual checks) inside a nix shell:
+  `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash <cmd>`
+- Two real sample files for integration checks live at `~/Downloads/tmp1/`:
+  - `photo_455@21-06-2026_15-17-04.jpg` — no EXIF; post date in filename → expect `2026:06:21 15:17:04`.
+  - `IMG_3449.MOV` — QuickTime CreateDate `2026:06:18 18:50:10`; no date in filename.
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `packages/media-tools/media-common.sh` | Add `FILENAME_DATE_PATTERNS` registry; rewrite `parse_date_from_filename` as a registry loop; add `resolve_date` and shared `fill_missing_dates`. |
+| `packages/media-tools/media-normalize.sh` | Drop local `fill_missing_dates`; call the shared one. |
+| `packages/media-tools/media-import.sh` | Replace `fill_missing_dates_for_import` with the shared `fill_missing_dates`. |
+| `packages/media-tools/media-info.sh` | New read-only inspector. |
+| `packages/media-tools/default.nix` | Add `media-info` to the wrap loop. |
+| `packages/media-tools/test/run-tests.sh` | Self-contained bash test runner (unit + integration). |
+
+---
+
+## Task 1: Test runner skeleton
+
+**Files:**
+- Create: `packages/media-tools/test/run-tests.sh`
+
+- [ ] **Step 1: Create the test runner with assertion helpers**
+
+```bash
+#!/usr/bin/env bash
+# Self-contained test runner for media-tools.
+# Run inside a nix shell that provides exiftool + coreutils + findutils:
+#   nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils \
+#     --command bash packages/media-tools/test/run-tests.sh
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=../media-common.sh
+source "$LIB_DIR/media-common.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "ok   - $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL - $desc"
+    echo "         expected: [$expected]"
+    echo "         actual:   [$actual]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Tests are appended below by later tasks.
+
+finish() {
+  echo "----------------------------------------"
+  echo "PASS: $PASS  FAIL: $FAIL"
+  [[ "$FAIL" -eq 0 ]]
+}
+```
+
+- [ ] **Step 2: Make it executable and run it**
+
+Run: `chmod +x packages/media-tools/test/run-tests.sh && nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+
+Expected: it sources the lib and prints `PASS: 0  FAIL: 0` (the `finish` call is added in the last step of Task 2; for now it may just exit cleanly after sourcing — if `finish` is undefined that's fine, no tests yet).
+
+> Note: `finish` is defined but not yet called. That happens at the end of Task 2 once the first tests exist.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/media-tools/test/run-tests.sh
+git commit -m "test(media-tools): add bash test runner skeleton"
+```
+
+---
+
+## Task 2: Pluggable filename-pattern registry
+
+Replace the hardcoded `if/elif` in `parse_date_from_filename` with a declarative registry. This is the core new logic and is pure (no exiftool), so it gets full unit-test coverage.
+
+**Files:**
+- Modify: `packages/media-tools/media-common.sh` (the `parse_date_from_filename` block, currently lines 11-31)
+- Modify: `packages/media-tools/test/run-tests.sh`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append before the `finish()` definition is called (i.e. add these test lines near the bottom of `run-tests.sh`, then add the `finish` call as the very last line):
+
+```bash
+# --- parse_date_from_filename (registry) ---
+assert_eq "prefixed IMG_ name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename 'IMG_20230115_143000.jpg')"
+assert_eq "bare YYYYMMDD_HHMMSS name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename '20230115_143000.jpg')"
+assert_eq "dashed ISO name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename '2023-01-15_14-30-00.jpg')"
+assert_eq "telegram day-first name" \
+  "2026:06:21 15:17:04" "$(parse_date_from_filename 'photo_455@21-06-2026_15-17-04.jpg')"
+assert_eq "no-match name returns empty" \
+  "" "$(parse_date_from_filename 'random_file.jpg')"
+
+# --- extensibility: appending one registry entry is enough ---
+FILENAME_DATE_PATTERNS+=(
+  "$(printf 'viber\tviber_image_([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})\t1 2 3 4 5 6')"
+)
+assert_eq "newly-registered viber pattern works without code change" \
+  "2025:12:31 09:08:07" "$(parse_date_from_filename 'viber_image_2025-12-31-09-08-07.jpg')"
+
+finish
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+
+Expected: FAILs — `telegram day-first name` fails (current code returns empty), `viber` fails (`FILENAME_DATE_PATTERNS` is undefined, treated as empty array). The prefixed/dashed/no-match cases pass against the old code.
+
+- [ ] **Step 3: Implement the registry + generic loop**
+
+In `media-common.sh`, replace the whole current block (lines ~11-31, from the `# Filename date patterns...` comment through the end of `parse_date_from_filename`) with:
+
+```bash
+# Pluggable filename date-pattern registry.
+# Each entry is TAB-separated: "<name>\t<ERE with 6 capture groups>\t<group-order>"
+# <group-order> is 6 space-separated BASH_REMATCH indices in Y M D H Mi S order.
+# Patterns are tried top to bottom; first match wins. Year-first patterns come
+# before day-first ones so they are never shadowed.
+# To support a new source (e.g. viber/whatsapp), append one line here — no code change.
+FILENAME_DATE_PATTERNS=(
+  "$(printf 'prefixed\t^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2})\t2 3 4 5 6 7')"
+  "$(printf 'dashed\t([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2})\t1 2 3 4 5 6')"
+  "$(printf 'telegram\t[@_]([0-9]{2})-([0-9]{2})-([0-9]{4})_([0-9]{2})-([0-9]{2})-([0-9]{2})\t3 2 1 4 5 6')"
+)
+
+# Parse a date from a filename using FILENAME_DATE_PATTERNS.
+# Echoes "YYYY:MM:DD HH:MM:SS" on first match, or empty string on no match.
+parse_date_from_filename() {
+  local filename
+  filename=$(basename "$1")
+  filename="${filename%.*}"  # strip extension
+
+  local entry name regex order
+  for entry in "${FILENAME_DATE_PATTERNS[@]}"; do
+    IFS=$'\t' read -r name regex order <<<"$entry"
+    if [[ "$filename" =~ $regex ]]; then
+      # shellcheck disable=SC2086
+      set -- $order  # positional params 1..6 = group indices for Y M D H Mi S
+      printf '%s:%s:%s %s:%s:%s\n' \
+        "${BASH_REMATCH[$1]}" "${BASH_REMATCH[$2]}" "${BASH_REMATCH[$3]}" \
+        "${BASH_REMATCH[$4]}" "${BASH_REMATCH[$5]}" "${BASH_REMATCH[$6]}"
+      return 0
+    fi
+  done
+  echo ""
+}
+
+# Echo the name of the filename-pattern that matches (or empty). Used by media-info.
+filename_pattern_name() {
+  local filename
+  filename=$(basename "$1")
+  filename="${filename%.*}"
+  local entry name regex order
+  for entry in "${FILENAME_DATE_PATTERNS[@]}"; do
+    IFS=$'\t' read -r name regex order <<<"$entry"
+    if [[ "$filename" =~ $regex ]]; then
+      echo "$name"
+      return 0
+    fi
+  done
+  echo ""
+}
+```
+
+> Why two functions: `parse_date_from_filename` keeps its exact existing contract (date string), and `filename_pattern_name` exposes the matched source label for `media-info` (Task 5) without changing that contract.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+
+Expected: all `parse_date_from_filename` + extensibility assertions `ok`, ending `PASS: 6  FAIL: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/media-tools/media-common.sh packages/media-tools/test/run-tests.sh
+git commit -m "feat(media-tools): pluggable filename date-pattern registry with telegram support"
+```
+
+---
+
+## Task 3: `resolve_date` precedence authority
+
+One helper encapsulating EXIF→filename→mtime precedence, returning both the date and its source. Integration-tested against the real sample files.
+
+**Files:**
+- Modify: `packages/media-tools/media-common.sh` (add after `parse_date_from_filename`/`filename_pattern_name`)
+- Modify: `packages/media-tools/test/run-tests.sh`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add a fixtures helper + tests to `run-tests.sh`, before the `finish` call. Guard on the sample files so the suite degrades gracefully if they're absent:
+
+```bash
+# --- resolve_date (integration; needs sample files + exiftool) ---
+SAMPLES="${MEDIA_TEST_SAMPLES:-$HOME/Downloads/tmp1}"
+PHOTO="$SAMPLES/photo_455@21-06-2026_15-17-04.jpg"
+VIDEO="$SAMPLES/IMG_3449.MOV"
+
+if [[ -f "$PHOTO" && -f "$VIDEO" ]]; then
+  WORK="$(mktemp -d)"
+  trap 'rm -rf "$WORK"' EXIT
+  cp "$PHOTO" "$WORK/"
+  cp "$VIDEO" "$WORK/"
+  # mtime-only fixture: telegram photo renamed so no pattern matches and EXIF is absent
+  cp "$PHOTO" "$WORK/random_name.jpg"
+
+  assert_eq "resolve_date: video uses EXIF" \
+    "2026:06:18 18:50:10	EXIF" "$(resolve_date "$WORK/IMG_3449.MOV")"
+  assert_eq "resolve_date: telegram photo uses filename" \
+    "2026:06:21 15:17:04	filename" "$(resolve_date "$WORK/photo_455@21-06-2026_15-17-04.jpg")"
+  # For the mtime case we only assert the source label (date == export mtime, varies)
+  assert_eq "resolve_date: unmatched photo falls back to mtime" \
+    "mtime" "$(resolve_date "$WORK/random_name.jpg" | cut -f2)"
+else
+  echo "skip - resolve_date integration (sample files not found at $SAMPLES)"
+fi
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+
+Expected: FAIL — `resolve_date: command not found` (or empty output) for the three new assertions.
+
+- [ ] **Step 3: Implement `resolve_date`**
+
+Add to `media-common.sh`:
+
+```bash
+# Decide which date a file would receive and where it comes from.
+# Precedence: embedded EXIF/QuickTime CreateDate -> filename pattern -> file mtime.
+# Echoes TAB-separated: "<YYYY:MM:DD HH:MM:SS>\t<EXIF|filename|mtime>".
+resolve_date() {
+  local file="$1"
+
+  local create_date
+  create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+  if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
+    printf '%s\t%s\n' "$create_date" "EXIF"
+    return 0
+  fi
+
+  local parsed
+  parsed=$(parse_date_from_filename "$file")
+  if [[ -n "$parsed" ]]; then
+    printf '%s\t%s\n' "$parsed" "filename"
+    return 0
+  fi
+
+  local mtime_date
+  mtime_date=$(exiftool -s3 -d "%Y:%m:%d %H:%M:%S" -FileModifyDate "$file" 2>/dev/null || true)
+  printf '%s\t%s\n' "$mtime_date" "mtime"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+
+Expected: the three `resolve_date` assertions `ok` (or `skip` line if samples absent — but they should be present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/media-tools/media-common.sh packages/media-tools/test/run-tests.sh
+git commit -m "feat(media-tools): add resolve_date precedence helper"
+```
+
+---
+
+## Task 4: Shared `fill_missing_dates` in common; wire normalize
+
+Move the fill chain into `media-common.sh`, built on `resolve_date`, and have `media-normalize` use it. Behavior must stay identical to today.
+
+**Files:**
+- Modify: `packages/media-tools/media-common.sh` (add `fill_missing_dates`)
+- Modify: `packages/media-tools/media-normalize.sh` (remove local `fill_missing_dates`, lines 146-185; keep the `set_dates`/`force_set_dates` wiring)
+
+- [ ] **Step 1: Add shared `fill_missing_dates` to `media-common.sh`**
+
+```bash
+# Fill missing CreateDate on all media files in <dir>, in place.
+# Skips files that already have a valid CreateDate (EXIF source).
+# Otherwise sets dates from the filename pattern, else from mtime.
+# Honors DRY_RUN and RECURSIVE globals. Mutates source files (-overwrite_original).
+fill_missing_dates() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  local ext file date source
+  for ext in $EXTENSIONS; do
+    while IFS= read -r -d '' file; do
+      IFS=$'\t' read -r date source < <(resolve_date "$file")
+      case "$source" in
+        EXIF)
+          continue ;;
+        filename)
+          if [[ "$DRY_RUN" == true ]]; then
+            print_info "[dry-run] Set date from filename: $file -> $date"
+          else
+            set_all_dates "$file" "$date"
+            print_info "Set date from filename: $file -> $date"
+          fi ;;
+        mtime)
+          if [[ "$DRY_RUN" == true ]]; then
+            print_info "[dry-run] Set date from mtime: $file"
+          else
+            set_all_dates "$file" --from-mtime
+            print_info "Set date from mtime: $file"
+          fi ;;
+      esac
+    done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
+  done
+}
+```
+
+> Note: the mtime branch still uses `set_all_dates --from-mtime` (not the resolved string) so the timezone-offset handling is preserved exactly as before.
+
+- [ ] **Step 2: Remove the local copy from `media-normalize.sh`**
+
+Delete the entire local `fill_missing_dates` function (media-normalize.sh:146-185). The `set_dates` function (line 92-100) already calls `fill_missing_dates "$dir"` — it now resolves to the shared one. Leave `force_set_dates` untouched.
+
+- [ ] **Step 3: Verify normalize behavior on the sample photo (dry-run)**
+
+Run:
+```bash
+nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash -c '
+  W=$(mktemp -d); cp ~/Downloads/tmp1/photo_455@21-06-2026_15-17-04.jpg "$W/";
+  bash packages/media-tools/media-normalize.sh --dry-run "$W"'
+```
+Expected: a line `[dry-run] Set date from filename: .../photo_455@21-06-2026_15-17-04.jpg -> 2026:06:21 15:17:04` (NOT from mtime).
+
+- [ ] **Step 4: Run the unit suite to confirm no regression**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+Expected: `FAIL: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/media-tools/media-common.sh packages/media-tools/media-normalize.sh
+git commit -m "refactor(media-tools): share fill_missing_dates via resolve_date"
+```
+
+---
+
+## Task 5: Wire `media-import` to the shared fill chain
+
+**Files:**
+- Modify: `packages/media-tools/media-import.sh` (remove `fill_missing_dates_for_import` lines 42-63; replace both call sites)
+
+- [ ] **Step 1: Delete `fill_missing_dates_for_import`**
+
+Remove the function (and its stale "source files are NOT modified" comment block, lines 42-63).
+
+- [ ] **Step 2: Replace its two call sites with the shared function**
+
+In `media-import.sh`, the `--move` branch (line ~114) and the copy branch (line ~147) each call `fill_missing_dates_for_import`. Replace both with:
+
+```bash
+  fill_missing_dates "$SRC"
+```
+
+`$SRC` is set at line 67; `DRY_RUN`/`RECURSIVE` are already in scope from `parse_common_args`. The shared function honors them.
+
+- [ ] **Step 3: Verify import maps the sample photo to the post date (dry-run)**
+
+> The import dry-run path uses exiftool's own `-p` mapping from `$CreateDate` and does not call `fill_missing_dates`, so to verify the fallback you check the non-dry copy path on a throwaway dir, or confirm via `resolve_date`. Use this end-to-end check:
+
+```bash
+nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash -c '
+  set -e
+  SRC=$(mktemp -d); DST=$(mktemp -d)
+  cp ~/Downloads/tmp1/photo_455@21-06-2026_15-17-04.jpg "$SRC/"
+  MEDIA_HOME="$DST" bash packages/media-tools/media-import.sh "$SRC"
+  echo "--- result tree ---"; find "$DST" -type f'
+```
+Expected: the file lands at `$DST/All/2026/06/20260621_151704.jpg` (post date), not under `2026/06/29`.
+
+- [ ] **Step 4: Run the unit suite**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+Expected: `FAIL: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/media-tools/media-import.sh
+git commit -m "fix(media-tools): import recovers telegram post dates via shared fill chain"
+```
+
+---
+
+## Task 6: New `media-info` inspector
+
+**Files:**
+- Create: `packages/media-tools/media-info.sh`
+- Modify: `packages/media-tools/test/run-tests.sh`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `run-tests.sh` (inside the `if [[ -f "$PHOTO" ... ]]` block from Task 3, or a new guarded block):
+
+```bash
+if [[ -f "$PHOTO" ]]; then
+  info_out="$(bash "$LIB_DIR/media-info.sh" "$WORK/photo_455@21-06-2026_15-17-04.jpg")"
+  assert_eq "media-info resolved source is filename" \
+    "1" "$(grep -c 'source: filename' <<<"$info_out")"
+  assert_eq "media-info would-become name is post date" \
+    "1" "$(grep -c '20260621_151704.jpg' <<<"$info_out")"
+fi
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+Expected: FAIL — `media-info.sh` does not exist yet.
+
+- [ ] **Step 3: Implement `media-info.sh`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+usage() {
+  cat <<EOF
+Usage: media-info FILE [FILE...]
+
+Show how each file's date would be resolved (EXIF -> filename -> mtime) before
+normalizing or importing. Read-only: modifies nothing.
+EOF
+}
+
+if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  [[ $# -eq 0 ]] && exit 1 || exit 0
+fi
+
+inspect() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    print_error "Not a file: $file"
+    return 1
+  fi
+
+  local create_date modify_date fs_date parsed pname resolved date source ext base
+  create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+  modify_date=$(exiftool -s3 -ModifyDate "$file" 2>/dev/null || true)
+  fs_date=$(exiftool -s3 -d "%Y:%m:%d %H:%M:%S" -FileModifyDate "$file" 2>/dev/null || true)
+  parsed=$(parse_date_from_filename "$file")
+  pname=$(filename_pattern_name "$file")
+
+  IFS=$'\t' read -r date source < <(resolve_date "$file")
+
+  ext="${file##*.}"
+  ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
+  # canonical name from resolved date (YYYY:MM:DD HH:MM:SS -> YYYYMMDD_HHMMSS)
+  base=$(echo "$date" | sed -E 's/[: ]//g')        # YYYYMMDDHHMMSS
+  base="${base:0:8}_${base:8:6}"
+
+  echo "$file"
+  printf '  EXIF CreateDate : %s\n' "${create_date:-(none)}"
+  printf '  EXIF ModifyDate : %s\n' "${modify_date:-(none)}"
+  printf '  FileModifyDate  : %s\n' "${fs_date:-(none)}"
+  if [[ -n "$parsed" ]]; then
+    printf '  Filename parse  : %s   (%s)\n' "$parsed" "$pname"
+  else
+    printf '  Filename parse  : (no match)\n'
+  fi
+  printf '  -> Resolved     : %s   [source: %s]\n' "$date" "$source"
+  printf '  -> Would become : %s.%s\n' "$base" "$ext"
+  echo ""
+}
+
+rc=0
+for f in "$@"; do
+  inspect "$f" || rc=1
+done
+exit "$rc"
+```
+
+- [ ] **Step 4: Run to verify pass + eyeball both samples**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+Expected: media-info assertions `ok`, `FAIL: 0`.
+
+Then eyeball both samples:
+```bash
+nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash -c '
+  bash packages/media-tools/media-info.sh \
+    ~/Downloads/tmp1/photo_455@21-06-2026_15-17-04.jpg \
+    ~/Downloads/tmp1/IMG_3449.MOV'
+```
+Expected: photo → `source: filename`, `20260621_151704.jpg`; video → `source: EXIF`, `20260618_185010.mov`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/media-tools/media-info.sh packages/media-tools/test/run-tests.sh
+git commit -m "feat(media-tools): add read-only media-info inspector"
+```
+
+---
+
+## Task 7: Package `media-info` + full validation
+
+**Files:**
+- Modify: `packages/media-tools/default.nix` (line 27 loop)
+
+- [ ] **Step 1: Add `media-info` to the wrap loop**
+
+In `default.nix`, change:
+
+```nix
+    for script in media-normalize media-import; do
+```
+to:
+```nix
+    for script in media-normalize media-import media-info; do
+```
+
+The existing `substituteInPlace` (SCRIPT_DIR patch) and `wrapProgram` (PATH prefix) then apply to `media-info` automatically.
+
+- [ ] **Step 2: Build the package**
+
+Run: `nix build .#media-tools` (or the appropriate attr — discover via `nix eval --json .#packages.aarch64-darwin --apply builtins.attrNames 2>/dev/null` or check how the package is referenced in the flake; fall back to `nix-build` on the derivation if needed).
+Expected: build succeeds; `result/bin/` contains `media-info`, `media-normalize`, `media-import`.
+
+- [ ] **Step 3: Run the wrapped binary (deps on PATH, no nix shell needed)**
+
+Run: `./result/bin/media-info ~/Downloads/tmp1/photo_455@21-06-2026_15-17-04.jpg`
+Expected: same output as Task 6 Step 4 — confirms wrapping put exiftool on PATH and the SCRIPT_DIR patch resolved `media-common.sh`.
+
+- [ ] **Step 4: Lint + format**
+
+Run: `just lint && just format-check`
+Expected: clean. If shellcheck flags the new scripts, fix and re-run. (Common: `SC2086` on intentional word-splitting already has `# shellcheck disable` in the existing code — follow that pattern.)
+
+- [ ] **Step 5: Full test suite final pass**
+
+Run: `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh`
+Expected: `FAIL: 0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/media-tools/default.nix
+git commit -m "build(media-tools): package media-info binary"
+```
+
+---
+
+## Done criteria
+
+- `media-info <photo>` reports `source: filename` and the post-date name; `<video>` reports `source: EXIF`.
+- `media-normalize` and `media-import` both recover Telegram post dates for the sample photo; video keeps its capture date.
+- Adding a new format is a single line appended to `FILENAME_DATE_PATTERNS`.
+- `run-tests.sh` is green; `just lint`/`format-check` clean; `nix build .#media-tools` succeeds.

--- a/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
+++ b/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
@@ -1,0 +1,154 @@
+# Design: Telegram post-date recovery and a `media-info` inspector for media-tools
+
+**Date:** 2026-06-29
+**Status:** Approved (design)
+**Component:** `packages/media-tools/`
+
+## Problem
+
+Media exported from Telegram channels imports with the wrong date.
+
+- **Photos:** Telegram strips all EXIF/metadata. The only embedded date carrier is the
+  filename, which uses a day-first format:
+  `photo_<id>@DD-MM-YYYY_HH-MM-SS.jpg` (e.g. `photo_455@21-06-2026_15-17-04.jpg` =
+  posted 2026-06-21 15:17:04). The current `parse_date_from_filename` only recognizes
+  `YYYYMMDD_HHMMSS` and ISO `YYYY-MM-DD` shapes, so the Telegram name does **not** match
+  and the tool falls through to the file modification time — which is the export/download
+  date (today), not the post date. **This is the reported bug.**
+- **Videos:** Telegram preserves QuickTime metadata. `IMG_3449.MOV` carries
+  `QuickTime:CreateDate = 2026:06:18 18:50:10` (real capture date), so videos already
+  import correctly via the existing EXIF-first precedence. No change needed for videos.
+
+Two structural issues compound the bug:
+
+1. `media-normalize` resolves missing dates via the chain EXIF → filename → mtime, but
+   `media-import` has a separate `fill_missing_dates_for_import` that fills from **mtime
+   only** — it never parses the filename. So even after fixing the filename parser, a
+   direct `media-import` on a Telegram export would still apply the export date.
+2. There is no read-only way to inspect a file and see which date the chain *would* pick
+   before mutating anything, which makes troubleshooting these cases tedious.
+
+## Goals
+
+- Recover the Telegram post date from photo filenames during both normalize and import.
+- Leave video (and any EXIF-bearing) behavior unchanged.
+- Provide a read-only `media-info <file>` tool to troubleshoot date resolution before
+  normalizing.
+- Keep a single source of truth for date-resolution precedence (no logic duplicated
+  across tools).
+
+## Non-goals
+
+- Broad/loose day-first date matching anywhere in a filename (rejected to avoid
+  misreading ambiguous names like `03-04-2026`). Matching is Telegram-specific.
+- Changing the canonical output filename format (`YYYYMMDD_HHMMSS`).
+- Any change to how EXIF-bearing files (e.g. videos) are dated.
+
+## Design
+
+### 1. Recognize the Telegram filename date
+
+In `media-common.sh`, extend `parse_date_from_filename` with a third pattern, tried
+**after** the existing `re_prefixed` and `re_dashed` patterns so it never shadows
+ISO-style names:
+
+```
+re_telegram='[@_]([0-9]{2})-([0-9]{2})-([0-9]{4})_([0-9]{2})-([0-9]{2})-([0-9]{2})'
+#            sep   DD          MM          YYYY        HH          MM          SS
+```
+
+- Anchored on the `@` or `_` separator that precedes the date in Telegram exports,
+  keeping the match tight (Telegram-specific scope).
+- Reorders day-first capture groups into exiftool's `YYYY:MM:DD HH:MM:SS`:
+  `photo_455@21-06-2026_15-17-04` → `2026:06:21 15:17:04`.
+
+Precedence is unchanged overall: **EXIF CreateDate → filename → mtime**.
+
+### 2. Share one fill-chain across both tools
+
+Currently `media-normalize`'s `fill_missing_dates` (EXIF→filename→mtime) and
+`media-import`'s `fill_missing_dates_for_import` (mtime-only) are separate
+implementations.
+
+- Move a single `fill_missing_dates <dir>` function into `media-common.sh`, implementing
+  the EXIF→filename→mtime chain and honoring the existing `DRY_RUN` and `RECURSIVE`
+  globals.
+- `media-normalize` calls the shared function (behavior identical to today).
+- `media-import` replaces `fill_missing_dates_for_import` with a call to the shared
+  function before its copy/move step, so a direct `media-import` on a Telegram export now
+  recovers post dates too.
+- `default.nix` already ships `media-common.sh`; no packaging change for this part.
+
+### 3. New `media-info <file>` troubleshooting tool
+
+A new read-only script `media-info.sh`, wrapped as `media-info` in `default.nix`
+alongside `media-normalize` and `media-import`. It mutates nothing; it explains what the
+chain *would* do.
+
+For the given file it prints:
+
+1. **Embedded date tags** — `DateTimeOriginal`, `CreateDate`, `ModifyDate` (EXIF/QuickTime)
+   via exiftool.
+2. **Filesystem date** — `FileModifyDate` (mtime), the last-resort fallback.
+3. **Filename parse** — what `parse_date_from_filename` extracts, or `(no match)`,
+   reusing the shared function so it cannot drift from real logic.
+4. **Resolved date + source** — the single date the normalize/import chain would pick,
+   labeled `EXIF` / `filename` / `mtime`.
+5. **Resulting name** — the canonical `YYYYMMDD_HHMMSS.ext` the file would be renamed to.
+
+To support clean reuse, factor the "resolve date + source" decision into a shared
+`resolve_date <file>` helper in `media-common.sh`, which both `media-info` (display) and
+the fill-chain (section 2) build on — one source of truth for precedence.
+
+Expected output for the two samples:
+
+```
+$ media-info photo_455@21-06-2026_15-17-04.jpg
+  EXIF CreateDate : (none)
+  FileModifyDate  : 2026:06:29 14:12:17   (export date)
+  Filename parse  : 2026:06:21 15:17:04   (telegram)
+  -> Resolved     : 2026:06:21 15:17:04   [source: filename]
+  -> Would become : 20260621_151704.jpg
+
+$ media-info IMG_3449.MOV
+  EXIF CreateDate : 2026:06:18 18:50:10
+  FileModifyDate  : 2026:06:29 14:12:16
+  Filename parse  : (no match)
+  -> Resolved     : 2026:06:18 18:50:10   [source: EXIF]
+  -> Would become : 20260618_185010.mov
+```
+
+`media-info` takes one or more file arguments. Usage error (no args / missing file) exits
+non-zero with a clear message. It does not require `MEDIA_HOME`.
+
+## Components touched
+
+| File | Change |
+|------|--------|
+| `media-common.sh` | Add `re_telegram` pattern to `parse_date_from_filename`; add shared `fill_missing_dates <dir>` and `resolve_date <file>` helpers |
+| `media-normalize.sh` | Use shared `fill_missing_dates` (drop local copy) |
+| `media-import.sh` | Replace `fill_missing_dates_for_import` with shared `fill_missing_dates` |
+| `media-info.sh` | New read-only inspector script |
+| `default.nix` | Add `media-info` to the wrapped-scripts loop |
+
+## Error handling
+
+- `media-info` with no arguments or a non-existent file: print error to stderr, exit 1.
+- Existing `DRY_RUN`/`RECURSIVE` semantics preserved for normalize and import.
+- Date parsing failures fall through the existing chain to mtime (unchanged safety net).
+
+## Testing / verification
+
+Against copies of the two sample files in a scratch dir:
+
+1. `media-info` on the photo reports `Resolved … [source: filename]` =
+   `2026:06:21 15:17:04` and `Would become 20260621_151704.jpg`.
+2. `media-info` on the video reports `Resolved … [source: EXIF]` =
+   `2026:06:18 18:50:10` and `Would become 20260618_185010.mov`.
+3. `media-normalize --dry-run` on the photo shows it setting the date from the filename
+   (post date), not mtime.
+4. `media-import --dry-run` on the photo maps it under `.../2026/06/20260621_151704.jpg`
+   (post date), confirming import now uses the filename fallback.
+5. `parse_date_from_filename` still returns the same results for existing
+   `IMG_YYYYMMDD_HHMMSS` and ISO `YYYY-MM-DD` names (no regression).
+6. `just lint` / shellcheck clean; `nix build` of the package succeeds.

--- a/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
+++ b/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
@@ -76,8 +76,15 @@ implementations.
 - `media-normalize` calls the shared function (behavior identical to today).
 - `media-import` replaces `fill_missing_dates_for_import` with a call to the shared
   function before its copy/move step, so a direct `media-import` on a Telegram export now
-  recovers post dates too.
+  recovers post dates too. Note: the old `fill_missing_dates_for_import` carries a stale
+  comment claiming source files are "NOT modified," but it actually mutates them via
+  `set_all_dates ... -overwrite_original`. Both the old and shared functions mutate in
+  place; drop/correct that comment when replacing it (behavior is unchanged).
 - `default.nix` already ships `media-common.sh`; no packaging change for this part.
+
+`media-info` is added to the existing `for script in ...` wrap loop in `default.nix`
+(not a separate install step), so it inherits the same `SCRIPT_DIR` `substituteInPlace`
+patch and `wrapProgram` PATH prefix and can `source` the installed `media-common.sh`.
 
 ### 3. New `media-info <file>` troubleshooting tool
 
@@ -99,6 +106,12 @@ For the given file it prints:
 To support clean reuse, factor the "resolve date + source" decision into a shared
 `resolve_date <file>` helper in `media-common.sh`, which both `media-info` (display) and
 the fill-chain (section 2) build on — one source of truth for precedence.
+
+**`resolve_date` contract:** prints exactly two tab-separated fields to stdout —
+`<date>\t<source>`, where `<date>` is `YYYY:MM:DD HH:MM:SS` and `<source>` is one of
+`EXIF` / `filename` / `mtime`. Callers split on the tab. This fixed shape is what both
+`media-info` and `fill_missing_dates` consume, so they cannot couple to different
+formats.
 
 Expected output for the two samples:
 

--- a/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
+++ b/docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md
@@ -46,21 +46,53 @@ Two structural issues compound the bug:
 
 ## Design
 
-### 1. Recognize the Telegram filename date
+### 1. A pluggable filename-pattern registry
 
-In `media-common.sh`, extend `parse_date_from_filename` with a third pattern, tried
-**after** the existing `re_prefixed` and `re_dashed` patterns so it never shadows
-ISO-style names:
+Today `parse_date_from_filename` hardcodes its patterns in an `if/elif` chain, and each
+branch reassembles `BASH_REMATCH` in its own ad-hoc group order. Adding a new source
+(Telegram now, Viber/WhatsApp/etc. later) means editing control flow. Replace this with a
+**declarative registry** so a new format is one table entry, no logic change.
+
+**Registry shape.** A single ordered, indexed array `FILENAME_DATE_PATTERNS` in
+`media-common.sh`. Each entry is one string with three tab-separated fields:
 
 ```
-re_telegram='[@_]([0-9]{2})-([0-9]{2})-([0-9]{4})_([0-9]{2})-([0-9]{2})-([0-9]{2})'
-#            sep   DD          MM          YYYY        HH          MM          SS
+"<name>\t<regex>\t<group-order>"
 ```
 
-- Anchored on the `@` or `_` separator that precedes the date in Telegram exports,
-  keeping the match tight (Telegram-specific scope).
-- Reorders day-first capture groups into exiftool's `YYYY:MM:DD HH:MM:SS`:
-  `photo_455@21-06-2026_15-17-04` → `2026:06:21 15:17:04`.
+- `<name>` — label for the source (`prefixed`, `dashed`, `telegram`, …). Surfaced by
+  `media-info` as the matched source and useful in errors.
+- `<regex>` — an ERE with six capture groups, stored as a string (preserving the existing
+  bash-5.3 workaround of not inlining regexes with bracket-space classes).
+- `<group-order>` — six space-separated `BASH_REMATCH` indices giving the groups in
+  **Y M D H Mi S** order. This is what makes day-first vs year-first formats declarative
+  instead of code: the assembler reads groups in this order and emits
+  `YYYY:MM:DD HH:MM:SS`. (Tab is the field delimiter because the regexes legitimately
+  contain spaces, e.g. `[_ ]`, but never literal tabs.)
+
+Initial registry (order = match precedence; first match wins):
+
+```
+prefixed  ^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2})   2 3 4 5 6 7
+dashed    ([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2})                     1 2 3 4 5 6
+telegram  [@_]([0-9]{2})-([0-9]{2})-([0-9]{4})_([0-9]{2})-([0-9]{2})-([0-9]{2})                          3 2 1 4 5 6
+```
+
+- The first two entries reproduce the current `re_prefixed` / `re_dashed` behavior
+  exactly (no regression).
+- `telegram` is the new entry: anchored on the `@`/`_` separator (Telegram-specific
+  scope), day-first, so group order `3 2 1 …` maps `21-06-2026` →
+  `2026:06:21`. It is listed **after** the year-first patterns so it never shadows
+  ISO-style names. Example: `photo_455@21-06-2026_15-17-04` → `2026:06:21 15:17:04`.
+
+**`parse_date_from_filename`** becomes a generic loop: strip the extension, iterate
+`FILENAME_DATE_PATTERNS` in order, test each `<regex>`, and on first match assemble the
+date from `<group-order>`. It still prints the `YYYY:MM:DD HH:MM:SS` string (or empty on
+no match) — its existing contract is unchanged, so all callers keep working.
+
+**Adding a future format (e.g. Viber)** = append one line to `FILENAME_DATE_PATTERNS`
+with its regex and group order. No edits to `parse_date_from_filename`, the fill-chain,
+or `media-info`.
 
 Precedence is unchanged overall: **EXIF CreateDate → filename → mtime**.
 
@@ -138,7 +170,7 @@ non-zero with a clear message. It does not require `MEDIA_HOME`.
 
 | File | Change |
 |------|--------|
-| `media-common.sh` | Add `re_telegram` pattern to `parse_date_from_filename`; add shared `fill_missing_dates <dir>` and `resolve_date <file>` helpers |
+| `media-common.sh` | Add `FILENAME_DATE_PATTERNS` registry (incl. new `telegram` entry); rewrite `parse_date_from_filename` as a generic registry loop; add shared `fill_missing_dates <dir>` and `resolve_date <file>` helpers |
 | `media-normalize.sh` | Use shared `fill_missing_dates` (drop local copy) |
 | `media-import.sh` | Replace `fill_missing_dates_for_import` with shared `fill_missing_dates` |
 | `media-info.sh` | New read-only inspector script |
@@ -163,5 +195,9 @@ Against copies of the two sample files in a scratch dir:
 4. `media-import --dry-run` on the photo maps it under `.../2026/06/20260621_151704.jpg`
    (post date), confirming import now uses the filename fallback.
 5. `parse_date_from_filename` still returns the same results for existing
-   `IMG_YYYYMMDD_HHMMSS` and ISO `YYYY-MM-DD` names (no regression).
-6. `just lint` / shellcheck clean; `nix build` of the package succeeds.
+   `IMG_YYYYMMDD_HHMMSS` and ISO `YYYY-MM-DD` names (no regression) — confirming the
+   `prefixed`/`dashed` registry entries reproduce prior behavior.
+6. Extensibility check: appending a throwaway entry to `FILENAME_DATE_PATTERNS` (e.g. a
+   `viber` regex with its own group order) makes a matching test filename resolve via
+   that entry, with no edit to `parse_date_from_filename`.
+7. `just lint` / shellcheck clean; `nix build` of the package succeeds.

--- a/packages/media-tools/default.nix
+++ b/packages/media-tools/default.nix
@@ -24,7 +24,7 @@ pkgs.stdenvNoCC.mkDerivation {
     cp media-common.sh $out/lib/media-tools/
 
     # Install scripts and wrap with runtime deps
-    for script in media-normalize media-import; do
+    for script in media-normalize media-import media-info; do
       cp "$script.sh" "$out/bin/$script"
       chmod +x "$out/bin/$script"
 

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -33,6 +33,10 @@ parse_date_from_filename() {
     if [[ "$filename" =~ $regex ]]; then
       # shellcheck disable=SC2086
       set -- $order  # positional params 1..6 = group indices for Y M D H Mi S
+      if [[ $# -ne 6 ]]; then
+        print_error "filename pattern '$name' has ${#} group-order tokens (need 6); skipping"
+        continue
+      fi
       printf '%s:%s:%s %s:%s:%s\n' \
         "${BASH_REMATCH[$1]}" "${BASH_REMATCH[$2]}" "${BASH_REMATCH[$3]}" \
         "${BASH_REMATCH[$4]}" "${BASH_REMATCH[$5]}" "${BASH_REMATCH[$6]}"

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -8,26 +8,54 @@ MIN_FILE_SIZE=30000  # 30KB - skip thumbnails/artifacts
 # Normalized filename pattern: YYYYMMDD_HHMMSS with optional -N suffix
 NORMALIZED_PATTERN='^[0-9]{8}_[0-9]{6}(-[0-9]+)?\.'
 
-# Filename date patterns for fallback parsing
-# Returns date string in "YYYY:MM:DD HH:MM:SS" exiftool format, or empty
+# Pluggable filename date-pattern registry.
+# Each entry is TAB-separated: "<name>\t<ERE with 6 capture groups>\t<group-order>"
+# <group-order> is 6 space-separated BASH_REMATCH indices in Y M D H Mi S order.
+# Patterns are tried top to bottom; first match wins. Year-first patterns come
+# before day-first ones so they are never shadowed.
+# To support a new source (e.g. viber/whatsapp), append one line here — no code change.
+FILENAME_DATE_PATTERNS=(
+  "$(printf 'prefixed\t^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2})\t2 3 4 5 6 7')"
+  "$(printf 'dashed\t([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2})\t1 2 3 4 5 6')"
+  "$(printf 'telegram\t[@_]([0-9]{2})-([0-9]{2})-([0-9]{4})_([0-9]{2})-([0-9]{2})-([0-9]{2})\t3 2 1 4 5 6')"
+)
+
+# Parse a date from a filename using FILENAME_DATE_PATTERNS.
+# Echoes "YYYY:MM:DD HH:MM:SS" on first match, or empty string on no match.
 parse_date_from_filename() {
   local filename
   filename=$(basename "$1")
   filename="${filename%.*}"  # strip extension
 
-  local date_str=""
+  local entry name regex order
+  for entry in "${FILENAME_DATE_PATTERNS[@]}"; do
+    IFS=$'\t' read -r name regex order <<<"$entry"
+    if [[ "$filename" =~ $regex ]]; then
+      # shellcheck disable=SC2086
+      set -- $order  # positional params 1..6 = group indices for Y M D H Mi S
+      printf '%s:%s:%s %s:%s:%s\n' \
+        "${BASH_REMATCH[$1]}" "${BASH_REMATCH[$2]}" "${BASH_REMATCH[$3]}" \
+        "${BASH_REMATCH[$4]}" "${BASH_REMATCH[$5]}" "${BASH_REMATCH[$6]}"
+      return 0
+    fi
+  done
+  echo ""
+}
 
-  # Try each pattern (stored in variables to avoid bash 5.3 regex parsing issues with spaces in bracket expressions)
-  local re_prefixed='^(IMG_|PXL_|VID_|Screenshot_)?([0-9]{4})([0-9]{2})([0-9]{2})_([0-9]{2})([0-9]{2})([0-9]{2})'
-  local re_dashed='([0-9]{4})-([0-9]{2})-([0-9]{2})[_ ]([0-9]{2})[-.]([0-9]{2})[-.]([0-9]{2})'
-
-  if [[ "$filename" =~ $re_prefixed ]]; then
-    date_str="${BASH_REMATCH[2]}:${BASH_REMATCH[3]}:${BASH_REMATCH[4]} ${BASH_REMATCH[5]}:${BASH_REMATCH[6]}:${BASH_REMATCH[7]}"
-  elif [[ "$filename" =~ $re_dashed ]]; then
-    date_str="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}:${BASH_REMATCH[3]} ${BASH_REMATCH[4]}:${BASH_REMATCH[5]}:${BASH_REMATCH[6]}"
-  fi
-
-  echo "$date_str"
+# Echo the name of the filename-pattern that matches (or empty). Used by media-info.
+filename_pattern_name() {
+  local filename
+  filename=$(basename "$1")
+  filename="${filename%.*}"
+  local entry name regex order
+  for entry in "${FILENAME_DATE_PATTERNS[@]}"; do
+    IFS=$'\t' read -r name regex order <<<"$entry"
+    if [[ "$filename" =~ $regex ]]; then
+      echo "$name"
+      return 0
+    fi
+  done
+  echo ""
 }
 
 # Get timezone offset in +HH:MM format for a given epoch (or current time)

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 EXTENSIONS="jpg jpeg png heic mp4 mov"
-FILENAME_FORMAT="%Y%m%d_%H%M%S%%-c.%%e"
+# %%le lowercases the extension so imported files match the normalized form
+# (e.g. .MOV -> .mov), consistent with media-normalize and media-info.
+FILENAME_FORMAT="%Y%m%d_%H%M%S%%-c.%%le"
 MIN_FILE_SIZE=30000  # 30KB - skip thumbnails/artifacts
 
 # Normalized filename pattern: YYYYMMDD_HHMMSS with optional -N suffix

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -67,6 +67,10 @@ filename_pattern_name() {
 # Echoes TAB-separated: "<YYYY:MM:DD HH:MM:SS>\t<EXIF|filename|mtime>".
 resolve_date() {
   local file="$1"
+  if [[ ! -f "$file" ]]; then
+    print_error "resolve_date: not a file: $file"
+    return 1
+  fi
 
   local create_date
   create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -168,6 +168,8 @@ fill_missing_dates() {
             set_all_dates "$file" --from-mtime
             print_info "Set date from mtime: $file"
           fi ;;
+        *)
+          print_error "fill_missing_dates: unknown source '$source' for $file" ;;
       esac
     done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
   done

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -136,6 +136,43 @@ set_all_dates() {
   fi
 }
 
+# Fill missing CreateDate on all media files in <dir>, in place.
+# Skips files that already have a valid CreateDate (EXIF source).
+# Otherwise sets dates from the filename pattern, else from mtime.
+# Honors DRY_RUN and RECURSIVE globals. Mutates source files (-overwrite_original).
+fill_missing_dates() {
+  local dir="$1"
+  local find_depth=("-maxdepth" "1")
+  if [[ "$RECURSIVE" == true ]]; then
+    find_depth=()
+  fi
+
+  local ext file date source
+  for ext in $EXTENSIONS; do
+    while IFS= read -r -d '' file; do
+      IFS=$'\t' read -r date source < <(resolve_date "$file")
+      case "$source" in
+        EXIF)
+          continue ;;
+        filename)
+          if [[ "$DRY_RUN" == true ]]; then
+            print_info "[dry-run] Set date from filename: $file -> $date"
+          else
+            set_all_dates "$file" "$date"
+            print_info "Set date from filename: $file -> $date"
+          fi ;;
+        mtime)
+          if [[ "$DRY_RUN" == true ]]; then
+            print_info "[dry-run] Set date from mtime: $file"
+          else
+            set_all_dates "$file" --from-mtime
+            print_info "Set date from mtime: $file"
+          fi ;;
+      esac
+    done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
+  done
+}
+
 # Build exiftool extension args: -ext jpg -ext jpeg -ext png ...
 exiftool_ext_args() {
   local args=""

--- a/packages/media-tools/media-common.sh
+++ b/packages/media-tools/media-common.sh
@@ -62,6 +62,31 @@ filename_pattern_name() {
   echo ""
 }
 
+# Decide which date a file would receive and where it comes from.
+# Precedence: embedded EXIF/QuickTime CreateDate -> filename pattern -> file mtime.
+# Echoes TAB-separated: "<YYYY:MM:DD HH:MM:SS>\t<EXIF|filename|mtime>".
+resolve_date() {
+  local file="$1"
+
+  local create_date
+  create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+  if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
+    printf '%s\t%s\n' "$create_date" "EXIF"
+    return 0
+  fi
+
+  local parsed
+  parsed=$(parse_date_from_filename "$file")
+  if [[ -n "$parsed" ]]; then
+    printf '%s\t%s\n' "$parsed" "filename"
+    return 0
+  fi
+
+  local mtime_date
+  mtime_date=$(exiftool -s3 -d "%Y:%m:%d %H:%M:%S" -FileModifyDate "$file" 2>/dev/null || true)
+  printf '%s\t%s\n' "$mtime_date" "mtime"
+}
+
 # Get timezone offset in +HH:MM format for a given epoch (or current time)
 # Usage: get_tz_offset [epoch]
 get_tz_offset() {

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -96,8 +96,7 @@ if [[ "$DRY_RUN" == true ]]; then
     IFS=$'\t' read -r rdate rsource < <(resolve_date "$file")
     compact="${rdate//[: ]/}"  # YYYY:MM:DD HH:MM:SS -> YYYYMMDDHHMMSS
     ext="${file##*.}"
-    ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
-    print_info "$file -> $DST/${compact:0:4}/${compact:4:2}/${compact:0:8}_${compact:8:6}.$ext  [$rsource]"
+    print_info "$file -> $DST/${compact:0:4}/${compact:4:2}/${compact:0:8}_${compact:8:6}.${ext,,}  [$rsource]"
   done
 elif [[ "$MOVE" == true ]]; then
   # Fill missing CreateDate (filename pattern, else mtime) so exiftool -o can

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -77,17 +77,31 @@ run_exiftool_import() {
 }
 
 if [[ "$DRY_RUN" == true ]]; then
-  # Preview: use -p to print source -> destination mapping without copying
-  # shellcheck disable=SC2086
-  exiftool \
-    $depth_args \
-    $(exiftool_ext_args) \
-    -if "\$filesize# > $MIN_FILE_SIZE" \
-    -p "\$filename -> $DST/\$CreateDate" \
-    -d "%Y/%m/%Y%m%d_%H%M%S.%le" \
-    "$SRC" 2>/dev/null || true
+  # Preview source -> destination without modifying anything. exiftool selects
+  # the same files a real run would (extensions + size threshold + depth); dates
+  # come from resolve_date (EXIF -> filename -> mtime) so Telegram filenames
+  # preview correctly — exiftool's $CreateDate would be blank for them.
+  mapfile -t preview_files < <(
+    # shellcheck disable=SC2086
+    exiftool -q -m $depth_args $(exiftool_ext_args) \
+      -if "\$filesize# > $MIN_FILE_SIZE" \
+      -p "\$Directory/\$FileName" \
+      "$SRC" 2>/dev/null || true
+  )
+
+  if [[ ${#preview_files[@]} -eq 0 ]]; then
+    print_info "No files to import."
+  fi
+  for file in "${preview_files[@]}"; do
+    IFS=$'\t' read -r rdate rsource < <(resolve_date "$file")
+    compact="${rdate//[: ]/}"  # YYYY:MM:DD HH:MM:SS -> YYYYMMDDHHMMSS
+    ext="${file##*.}"
+    ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
+    print_info "$file -> $DST/${compact:0:4}/${compact:4:2}/${compact:0:8}_${compact:8:6}.$ext  [$rsource]"
+  done
 elif [[ "$MOVE" == true ]]; then
-  # Fill missing CreateDate from mtime so exiftool -o can resolve all files
+  # Fill missing CreateDate (filename pattern, else mtime) so exiftool -o can
+  # resolve all files. NOTE: writes EXIF tags back to the SOURCE files.
   fill_missing_dates "$SRC"
 
   # Collect matching source file paths before copying
@@ -120,7 +134,8 @@ elif [[ "$MOVE" == true ]]; then
     done
   fi
 else
-  # Fill missing CreateDate from mtime so exiftool -o can resolve all files
+  # Fill missing CreateDate (filename pattern, else mtime) so exiftool -o can
+  # resolve all files. NOTE: writes EXIF tags back to the SOURCE files.
   fill_missing_dates "$SRC"
 
   # Copy mode

--- a/packages/media-tools/media-import.sh
+++ b/packages/media-tools/media-import.sh
@@ -39,29 +39,6 @@ parse_args() {
   parse_common_args "${remaining[@]}"
 }
 
-# Ensure all matching files have a CreateDate (fill from mtime if missing).
-# This is done in a temporary copy of metadata only — source files are NOT modified.
-# Exiftool's -o with date format skips files without CreateDate, so we need this.
-fill_missing_dates_for_import() {
-  local find_depth=("-maxdepth" "1")
-  if [[ "$RECURSIVE" == true ]]; then
-    find_depth=()
-  fi
-
-  for ext in $EXTENSIONS; do
-    while IFS= read -r -d '' file; do
-      local create_date
-      create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
-
-      if [[ -z "$create_date" || "$create_date" == "0000:00:00 00:00:00" ]]; then
-        if [[ "$DRY_RUN" == false ]]; then
-          set_all_dates "$file" --from-mtime 2>/dev/null || true
-        fi
-      fi
-    done < <(find "$SRC" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
-  done
-}
-
 # Main
 parse_args "$@"
 SRC="${POSITIONAL[0]:-.}"
@@ -111,7 +88,7 @@ if [[ "$DRY_RUN" == true ]]; then
     "$SRC" 2>/dev/null || true
 elif [[ "$MOVE" == true ]]; then
   # Fill missing CreateDate from mtime so exiftool -o can resolve all files
-  fill_missing_dates_for_import
+  fill_missing_dates "$SRC"
 
   # Collect matching source file paths before copying
   mapfile -d '' src_files < <(
@@ -144,7 +121,7 @@ elif [[ "$MOVE" == true ]]; then
   fi
 else
   # Fill missing CreateDate from mtime so exiftool -o can resolve all files
-  fill_missing_dates_for_import
+  fill_missing_dates "$SRC"
 
   # Copy mode
   run_exiftool_import -o . "-FileName<CreateDate" -d "$date_format" -progress

--- a/packages/media-tools/media-info.sh
+++ b/packages/media-tools/media-info.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=media-common.sh
+source "$SCRIPT_DIR/media-common.sh"
+
+usage() {
+  cat <<EOF
+Usage: media-info FILE [FILE...]
+
+Show how each file's date would be resolved (EXIF -> filename -> mtime) before
+normalizing or importing. Read-only: modifies nothing.
+EOF
+}
+
+if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  [[ $# -eq 0 ]] && exit 1 || exit 0
+fi
+
+inspect() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    print_error "Not a file: $file"
+    return 1
+  fi
+
+  local create_date modify_date fs_date parsed pname date source ext base
+  create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
+  modify_date=$(exiftool -s3 -ModifyDate "$file" 2>/dev/null || true)
+  fs_date=$(exiftool -s3 -d "%Y:%m:%d %H:%M:%S" -FileModifyDate "$file" 2>/dev/null || true)
+  parsed=$(parse_date_from_filename "$file")
+  pname=$(filename_pattern_name "$file")
+
+  IFS=$'\t' read -r date source < <(resolve_date "$file")
+
+  ext="${file##*.}"
+  ext="${ext,,}"
+  # canonical name from resolved date (YYYY:MM:DD HH:MM:SS -> YYYYMMDD_HHMMSS)
+  base="${date//[: ]/}"
+  base="${base:0:8}_${base:8:6}"
+
+  echo "$file"
+  printf '  EXIF CreateDate : %s\n' "${create_date:-(none)}"
+  printf '  EXIF ModifyDate : %s\n' "${modify_date:-(none)}"
+  printf '  FileModifyDate  : %s\n' "${fs_date:-(none)}"
+  if [[ -n "$parsed" ]]; then
+    printf '  Filename parse  : %s   (%s)\n' "$parsed" "$pname"
+  else
+    printf '  Filename parse  : (no match)\n'
+  fi
+  printf '  -> Resolved     : %s   [source: %s]\n' "$date" "$source"
+  printf '  -> Would become : %s.%s\n' "$base" "$ext"
+  echo ""
+}
+
+rc=0
+for f in "$@"; do
+  inspect "$f" || rc=1
+done
+exit "$rc"

--- a/packages/media-tools/media-info.sh
+++ b/packages/media-tools/media-info.sh
@@ -26,7 +26,7 @@ inspect() {
     return 1
   fi
 
-  local create_date modify_date fs_date parsed pname date source ext base
+  local create_date modify_date fs_date parsed pname date source ext base would_become
   create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
   modify_date=$(exiftool -s3 -ModifyDate "$file" 2>/dev/null || true)
   fs_date=$(exiftool -s3 -d "%Y:%m:%d %H:%M:%S" -FileModifyDate "$file" 2>/dev/null || true)
@@ -36,10 +36,14 @@ inspect() {
   IFS=$'\t' read -r date source < <(resolve_date "$file")
 
   ext="${file##*.}"
-  ext="${ext,,}"
+  [[ "$ext" == "$file" ]] && ext="" || ext="${ext,,}"
+
   # canonical name from resolved date (YYYY:MM:DD HH:MM:SS -> YYYYMMDD_HHMMSS)
-  base="${date//[: ]/}"
-  base="${base:0:8}_${base:8:6}"
+  would_become="(could not determine)"
+  if [[ "$date" =~ ^[0-9]{4}:[0-9]{2}:[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}$ ]]; then
+    base="${date//[: ]/}"
+    would_become="${base:0:8}_${base:8:6}${ext:+.$ext}"
+  fi
 
   echo "$file"
   printf '  EXIF CreateDate : %s\n' "${create_date:-(none)}"
@@ -50,8 +54,8 @@ inspect() {
   else
     printf '  Filename parse  : (no match)\n'
   fi
-  printf '  -> Resolved     : %s   [source: %s]\n' "$date" "$source"
-  printf '  -> Would become : %s.%s\n' "$base" "$ext"
+  printf '  -> Resolved     : %s   [source: %s]\n' "${date:-(none)}" "${source:-?}"
+  printf '  -> Would become : %s\n' "$would_become"
   echo ""
 }
 

--- a/packages/media-tools/media-normalize.sh
+++ b/packages/media-tools/media-normalize.sh
@@ -142,48 +142,6 @@ force_set_dates() {
   done < <(collect_media_files "$dir")
 }
 
-# Fallback chain mode: fill missing dates only
-fill_missing_dates() {
-  local dir="$1"
-  local find_depth=("-maxdepth" "1")
-  if [[ "$RECURSIVE" == true ]]; then
-    find_depth=()
-  fi
-
-  for ext in $EXTENSIONS; do
-    while IFS= read -r -d '' file; do
-      local create_date
-      create_date=$(exiftool -s3 -CreateDate "$file" 2>/dev/null || true)
-
-      if [[ -n "$create_date" && "$create_date" != "0000:00:00 00:00:00" ]]; then
-        continue
-      fi
-
-      # Fallback 1: parse from filename
-      local parsed_date
-      parsed_date=$(parse_date_from_filename "$file")
-
-      if [[ -n "$parsed_date" ]]; then
-        if [[ "$DRY_RUN" == true ]]; then
-          print_info "[dry-run] Set date from filename: $file -> $parsed_date"
-        else
-          set_all_dates "$file" "$parsed_date"
-          print_info "Set date from filename: $file -> $parsed_date"
-        fi
-        continue
-      fi
-
-      # Fallback 2: file modification date
-      if [[ "$DRY_RUN" == true ]]; then
-        print_info "[dry-run] Set date from mtime: $file"
-      else
-        set_all_dates "$file" --from-mtime
-        print_info "Set date from mtime: $file"
-      fi
-    done < <(find "$dir" "${find_depth[@]}" -iname "*.$ext" -type f -print0 2>/dev/null)
-  done
-}
-
 # Step 3: Rename files to canonical format
 rename_files() {
   local dir="$1"

--- a/packages/media-tools/test/run-tests.sh
+++ b/packages/media-tools/test/run-tests.sh
@@ -73,6 +73,13 @@ if [[ -f "$PHOTO" && -f "$VIDEO" ]]; then
     "mtime" "$(resolve_date "$WORK/random_name.jpg" | cut -f2)"
   assert_eq "resolve_date: missing file returns non-zero" \
     "1" "$(resolve_date "$WORK/does_not_exist.jpg" >/dev/null 2>&1; echo $?)"
+
+  # --- media-info (integration) ---
+  info_out="$(bash "$LIB_DIR/media-info.sh" "$WORK/photo_455@21-06-2026_15-17-04.jpg")"
+  assert_eq "media-info resolved source is filename" \
+    "1" "$(grep -c 'source: filename' <<<"$info_out")"
+  assert_eq "media-info would-become name is post date" \
+    "1" "$(grep -c '20260621_151704.jpg' <<<"$info_out")"
 else
   echo "skip - resolve_date integration (sample files not found at $SAMPLES)"
 fi

--- a/packages/media-tools/test/run-tests.sh
+++ b/packages/media-tools/test/run-tests.sh
@@ -26,10 +26,29 @@ assert_eq() {
   fi
 }
 
-# Tests are appended below by later tasks.
-
 finish() {
   echo "----------------------------------------"
   echo "PASS: $PASS  FAIL: $FAIL"
   [[ "$FAIL" -eq 0 ]]
 }
+
+# --- parse_date_from_filename (registry) ---
+assert_eq "prefixed IMG_ name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename 'IMG_20230115_143000.jpg')"
+assert_eq "bare YYYYMMDD_HHMMSS name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename '20230115_143000.jpg')"
+assert_eq "dashed ISO name" \
+  "2023:01:15 14:30:00" "$(parse_date_from_filename '2023-01-15_14-30-00.jpg')"
+assert_eq "telegram day-first name" \
+  "2026:06:21 15:17:04" "$(parse_date_from_filename 'photo_455@21-06-2026_15-17-04.jpg')"
+assert_eq "no-match name returns empty" \
+  "" "$(parse_date_from_filename 'random_file.jpg')"
+
+# --- extensibility: appending one registry entry is enough ---
+FILENAME_DATE_PATTERNS+=(
+  "$(printf 'viber\tviber_image_([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})\t1 2 3 4 5 6')"
+)
+assert_eq "newly-registered viber pattern works without code change" \
+  "2025:12:31 09:08:07" "$(parse_date_from_filename 'viber_image_2025-12-31-09-08-07.jpg')"
+
+finish

--- a/packages/media-tools/test/run-tests.sh
+++ b/packages/media-tools/test/run-tests.sh
@@ -71,6 +71,8 @@ if [[ -f "$PHOTO" && -f "$VIDEO" ]]; then
   # For the mtime case we only assert the source label (date == export mtime, varies)
   assert_eq "resolve_date: unmatched photo falls back to mtime" \
     "mtime" "$(resolve_date "$WORK/random_name.jpg" | cut -f2)"
+  assert_eq "resolve_date: missing file returns non-zero" \
+    "1" "$(resolve_date "$WORK/does_not_exist.jpg" >/dev/null 2>&1; echo $?)"
 else
   echo "skip - resolve_date integration (sample files not found at $SAMPLES)"
 fi

--- a/packages/media-tools/test/run-tests.sh
+++ b/packages/media-tools/test/run-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Self-contained test runner for media-tools.
+# Run inside a nix shell that provides exiftool + coreutils + findutils:
+#   nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils \
+#     --command bash packages/media-tools/test/run-tests.sh
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "$TEST_DIR/.." && pwd)"
+# shellcheck source=../media-common.sh
+source "$LIB_DIR/media-common.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "ok   - $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL - $desc"
+    echo "         expected: [$expected]"
+    echo "         actual:   [$actual]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Tests are appended below by later tasks.
+
+finish() {
+  echo "----------------------------------------"
+  echo "PASS: $PASS  FAIL: $FAIL"
+  [[ "$FAIL" -eq 0 ]]
+}

--- a/packages/media-tools/test/run-tests.sh
+++ b/packages/media-tools/test/run-tests.sh
@@ -51,4 +51,28 @@ FILENAME_DATE_PATTERNS+=(
 assert_eq "newly-registered viber pattern works without code change" \
   "2025:12:31 09:08:07" "$(parse_date_from_filename 'viber_image_2025-12-31-09-08-07.jpg')"
 
+# --- resolve_date (integration; needs sample files + exiftool) ---
+SAMPLES="${MEDIA_TEST_SAMPLES:-$HOME/Downloads/tmp1}"
+PHOTO="$SAMPLES/photo_455@21-06-2026_15-17-04.jpg"
+VIDEO="$SAMPLES/IMG_3449.MOV"
+
+if [[ -f "$PHOTO" && -f "$VIDEO" ]]; then
+  WORK="$(mktemp -d)"
+  trap 'rm -rf "$WORK"' EXIT
+  cp "$PHOTO" "$WORK/"
+  cp "$VIDEO" "$WORK/"
+  # mtime-only fixture: telegram photo renamed so no pattern matches and EXIF is absent
+  cp "$PHOTO" "$WORK/random_name.jpg"
+
+  assert_eq "resolve_date: video uses EXIF" \
+    "2026:06:18 18:50:10	EXIF" "$(resolve_date "$WORK/IMG_3449.MOV")"
+  assert_eq "resolve_date: telegram photo uses filename" \
+    "2026:06:21 15:17:04	filename" "$(resolve_date "$WORK/photo_455@21-06-2026_15-17-04.jpg")"
+  # For the mtime case we only assert the source label (date == export mtime, varies)
+  assert_eq "resolve_date: unmatched photo falls back to mtime" \
+    "mtime" "$(resolve_date "$WORK/random_name.jpg" | cut -f2)"
+else
+  echo "skip - resolve_date integration (sample files not found at $SAMPLES)"
+fi
+
 finish


### PR DESCRIPTION
## Summary

Telegram-exported **photos** lost their real date: Telegram strips EXIF, so the only date carrier is the filename (`photo_<id>@DD-MM-YYYY_HH-MM-SS.jpg`), which the date parser didn't recognize — files fell back to the export/download mtime. This fixes that and adds a read-only inspector for troubleshooting.

- **Pluggable filename-date registry** (`FILENAME_DATE_PATTERNS`): replaces hardcoded `if/elif` with declarative `name / regex / group-order` entries. Adds a day-first `telegram` pattern. New formats (Viber, WhatsApp, …) are a **one-line** addition — no code change.
- **`resolve_date`**: single precedence authority — embedded EXIF/QuickTime CreateDate → filename pattern → file mtime — returning `<date>\t<source>`.
- **Shared `fill_missing_dates`**: both `media-normalize` and `media-import` now use it, so a direct import recovers post dates (previously import was mtime-only).
- **`media-info <file>`** (new): read-only inspector showing embedded tags, mtime, filename parse, the resolved date + source, and the would-be canonical name.
- **Accurate import dry-run**: preview now resolves dates in bash (old preview used exiftool `$CreateDate`, blank for Telegram photos) and shows the resolution source.
- **Consistent canonical name**: `FILENAME_FORMAT` lowercases the extension (`%le`) so import output matches `media-normalize`/`media-info` (e.g. `.MOV` → `.mov`).
- **Tests**: new self-contained `test/run-tests.sh` (12 tests) — unit (registry incl. extensibility) + integration against real sample files.

Videos are unchanged: Telegram preserves QuickTime metadata, so EXIF-first precedence keeps their real capture date.

Spec: `docs/superpowers/specs/2026-06-29-media-tools-telegram-date-design.md`
Plan: `docs/superpowers/plans/2026-06-29-media-tools-telegram-date.md`

## Test Plan

- [x] `nix shell nixpkgs#exiftool nixpkgs#coreutils nixpkgs#findutils --command bash packages/media-tools/test/run-tests.sh` → 12/12 pass
- [x] `nix build .#packages.aarch64-darwin.media-tools` succeeds; wrapped `media-info` runs standalone
- [x] End-to-end on real samples: photo → `2026/06/20260621_151704.jpg` (post date), video → `2026/06/20260618_185010.mov` (EXIF capture date)
- [x] `just format-check` clean; `just lint` failure is pre-existing and unrelated (statix W20 in `modules/home/development/platforms/node/default.nix`)

## Known follow-up (out of scope)

`media-normalize`'s `lowercase_extensions` uses `mv FOO.MOV foo.mov`, which is a no-op error on case-insensitive filesystems (macOS APFS) and aborts the run under `set -e`. Pre-existing; not touched here. The import path no longer depends on it for lowercase extensions.